### PR TITLE
Refactor bar chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,144 @@
 [![Travis Status][trav_img]][trav_site]
 
-Starter Victory Component
-=========================
+VictoryBar
+=============
+VictoryBar creates a set of bars from data. Bar is a composable component, so it does not include an axis.  Check out VictoryChart for easy to use bar charts and more.
 
-UPDATE THIS README!
+## API
+
+There are several configuration options for Victory Bar, but if only the `data`is prop is provided, a sensible bar chart will still be rendered.
+
+### Props
+
+All props are optional, but you wont get very far without passing in some data.
+
+#### data
+
+The data prop specifies the data to be plotted. Data should be in the form of an array of data points, or an array of arrays of data points for multiple datasets. Each data point should be an object with x and y properties. Other properties may be added to the data point object, such as color, and opacity. These properties will be interpreted and applied to the individual bar.
+
+examples:
+
+```
+data={[
+  {x: new Date(1982, 1, 1), y: 125, color: "red"},
+  {x: new Date(1987, 1, 1), y: 257, color: "blue"},
+  {x: new Date(1993, 1, 1), y: 345, color: "green"}
+]}
+
+data={[
+  [{x: 5, y: 3}, {x: 4, y: 2}, {x: 3, y: 1}],
+  [{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 4}],
+  [{x: 1, y: 2}, {x: 2, y: 2}, {x: 3, y: 2}]
+]}
+```
+
+### dataAttributes
+
+The dataAttributes prop describes how a data set should be styled.
+This prop can be given as an object, or an array of objects. If this prop is
+given as an array of objects, the properties of each object in the array will
+be applied to the data points in the corresponding array of the data prop.
+
+examples:
+
+```
+dataAttributes={{color: "blue", opacity: 0.8}}
+
+dataAttributes={[
+  {color: "green"}, 
+  {color: "orange", opacity: 0.4}
+]}
+
+```
+ 
+### scale
+
+The scale prop determines which scales your bar chart should use. This prop can be given as a function, or as an object that specifies separate functions for x and y. Supported scales are d3 linear scales, time scales, power scales, and log scales. d3 ordinal scales are not supported, but non-numeric data is automatically handled and range band like behavior is supported via the `categories` prop.
+
+examples:
+
+```
+scale={() => d3.time.scale()}
+
+scale={{x: () => d3.scale.linear(), y: () => d3.scale.log()}}
+```
+
+### domain
+
+The domain prop describes the range of values your bar chart will include. This prop can be given as a array of the minimum and maximum expected values for your chart, or as an object that specifies separate arrays for x and y.
+If this prop is not provided, a domain will be calculated from data, or other available information.
+
+examples:
+
+```
+domain={[-1, 1]}
+
+domain={{x: [0, 100], y: [0, 1]}}
+```
+
+### range
+
+The range prop describes the range of pixels your ber chart will cover. This prop can begiven as a array of the minimum and maximum expected values for your chart, or as an object that specifies separate arrays for x and y.
+If this prop is not provided, a range will be calculated based on the height,
+width, and margin provided in the style prop, or in default styles. It is usually a good idea to let the bar component calculate its own range.
+
+examples:
+
+```
+range={[0, 500]} 
+
+range={{x: [0, 500], y: [500, 300]}}
+```
+
+### containerElement
+
+The containerElement prop specifies which element the compnent will render.
+For standalone bar components, the containerElement prop should be "svg". If you need to compose bar with other chart components , the containerElement prop should be "g", and will need to be rendered within an svg tag.
+
+### style
+
+The style prop specifies styles for your chart. VictoryBar relies on Radium,
+so valid Radium style objects should work for this prop, however height, width, and margin are used to calculate range, and need to be expressed as a number of pixels
+
+example:
+
+```
+style={{color: "red", width: 500, height: 300}}
+```
+
+### barWidth
+
+The barWidth prop specifies the width in number of pixels for bars rendered in the bar chart.
+
+### barPadding
+
+The barPadding prop specifies the padding in number of pixels between bars
+rendered in the bar chart.
+
+### domainPadding
+
+The domainPadding prop specifies a number of pixels of padding to add to the beginning and end of a domain. This prop is useful for explicitly spacing groups of bars farther from the origin to prevent crowding. This prop should be given as an object with numbers specified for x and y.
+
+example: `{x: 20, y: 0}`
+
+### categories
+
+The categories prop specifies the categories for a bar chart. This prop should be given as an array of string values, numeric values, or arrays. When this prop is given as an array of arrays, the minimum and maximum values of the arrays define range bands, allowing numeric data to be grouped into segments.
+
+examples:
+
+```
+categories={["dogs", "cats", "mice"]}
+
+categories={[
+  [0, 5], 
+  [5, 10], 
+  [10, 15]
+]}
+```
+
+### animate
+The animate prop determines whether the chart should animate with changing data.
 
 ## Development
 

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -18,15 +18,15 @@ class App extends React.Component {
     return _.map(_.range(5), () => {
       return [
         {
-          x: "red",
+          x: "rabbits",
           y: _.random(1, 5)
         },
         {
-          x: "green",
+          x: "cats",
           y: _.random(1, 10)
         },
         {
-          x: "blue",
+          x: "dogs",
           y: _.random(1, 15)
         }
       ];

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -8,7 +8,8 @@ class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      barData: this.getBarData()
+      barData: this.getBarData(),
+      numericBarData: this.getNumericBarData()
     };
   }
 
@@ -32,10 +33,30 @@ class App extends React.Component {
     });
   }
 
+  getNumericBarData() {
+    return _.map(_.range(5), () => {
+      return [
+        {
+          x: _.random(1, 3),
+          y: _.random(1, 5)
+        },
+        {
+          x: _.random(4, 7),
+          y: _.random(1, 10)
+        },
+        {
+          x: _.random(9, 11),
+          y: _.random(1, 15)
+        }
+      ];
+    });
+  }
+
   componentWillMount() {
     window.setInterval(() => {
       this.setState({
-        barData: this.getBarData()
+        barData: this.getBarData(),
+        numericBarData: this.getNumericBarData()
       });
     }, 4000);
   }
@@ -44,8 +65,20 @@ class App extends React.Component {
     return (
       <div className="demo">
         <p>
-
           <VictoryBar
+            data={this.state.numericBarData}
+            dataAttributes={[
+              {color: "cornflowerblue"},
+              {color: "orange"},
+              {color: "greenyellow"},
+              {color: "gold"},
+              {color: "tomato"}
+            ]}
+            categories={[[1, 3], [4, 7], [9, 11]]}
+            containerElement="svg"
+            animate={true}/>
+
+            <VictoryBar
             data={this.state.barData}
             dataAttributes={[
               {color: "cornflowerblue"},
@@ -54,11 +87,10 @@ class App extends React.Component {
               {color: "gold"},
               {color: "tomato"}
             ]}
-            domainOffset={{
-              x: 0.2,
-              y: 0
-            }}
+            stacked={true}
+            containerElement="svg"
             animate={true}/>
+
 
         </p>
       </div>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -1,30 +1,66 @@
 /*global document:false*/
+/*global window:false*/
+import _ from "lodash";
 import React from "react";
 import {VictoryBar} from "../src/index";
-import data from "./data";
 
 class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      barData: this.getBarData()
+    };
+  }
+
+
+  getBarData() {
+    return _.map(_.range(5), () => {
+      return [
+        {
+          x: "red",
+          y: _.random(1, 5)
+        },
+        {
+          x: "green",
+          y: _.random(1, 10)
+        },
+        {
+          x: "blue",
+          y: _.random(1, 15)
+        }
+      ];
+    });
+  }
+
+  componentWillMount() {
+    window.setInterval(() => {
+      this.setState({
+        barData: this.getBarData()
+      });
+    }, 4000);
+  }
+
   render() {
     return (
-      <div>
+      <div className="demo">
+        <p>
 
-
-        <svg
-          width={800}
-          height={600}
-          className={"SVG-OUTSIDE-COMPONENT"}
-          style={{border: "1px solid black"}}>
           <VictoryBar
-            data={[
-              {x: 1, y: 3},
-              {x: 2, y: 5},
-              {x: 3, y: 2},
-              {x: 4, y: 4},
-              {x: 5, y: 6}
+            data={this.state.barData}
+            dataAttributes={[
+              {color: "cornflowerblue"},
+              {color: "orange"},
+              {color: "greenyellow"},
+              {color: "gold"},
+              {color: "tomato"}
             ]}
-            barPadding={0.5}
-            containerElement="g"/>
-        </svg>
+            domainOffset={{
+              x: 0.2,
+              y: 0
+            }}
+            animate={true}/>
+
+        </p>
       </div>
     );
   }

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -6,20 +6,26 @@ import data from "./data";
 class App extends React.Component {
   render() {
     return (
-      <svg
-        width={800}
-        height={600}
-        className={"SVG-OUTSIDE-COMPONENT"}
-        style={{border: "1px solid black"}}>
-        <VictoryBar
-          data={data}
-          barPadding={0.5}
-          totalReductionInX={600}
-          totalReductionInY={500}
-          translateX={100}
-          translateY={300}
-          svg={false}/>
-      </svg>
+      <div>
+
+
+        <svg
+          width={800}
+          height={600}
+          className={"SVG-OUTSIDE-COMPONENT"}
+          style={{border: "1px solid black"}}>
+          <VictoryBar
+            data={[
+              {x: 1, y: 3},
+              {x: 2, y: 5},
+              {x: 3, y: 2},
+              {x: 4, y: 4},
+              {x: 5, y: 6}
+            ]}
+            barPadding={0.5}
+            containerElement="g"/>
+        </svg>
+      </div>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "rimraf": "^2.4.0",
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
+    "victory-animation": "^0.0.6",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -18,7 +18,7 @@ class VBar extends React.Component {
       opacity: 1,
       margin: 20,
       width: 500,
-      height: 500,
+      height: 300,
       fontFamily: "Helvetica",
       fontSize: 10,
       textAnchor: "middle"

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -5,145 +5,395 @@ import d3 from "d3";
 
 @Radium
 class VictoryBar extends React.Component {
-  drawStackedBars() {
-    // make a copy so we don't mutate props
-    const localCopyOfData = _.cloneDeep(this.props.data);
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.state.stringMap = {
+      x: this.createStringMap(props, "x"),
+      y: this.createStringMap(props, "y")
+    };
+    this.state.data = this.consolidateData(props);
+  }
 
-    // set up color scales, this will be abstracted
-    const color = d3.scale.ordinal()
-      .range(this.props.colorCategories).domain(
-        d3.keys(localCopyOfData[0])
-          .filter((key) => {
-            return key !== "label";
-          })
-      );
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      stringMap: {
+        x: this.createStringMap(nextProps, "x"),
+        y: this.createStringMap(nextProps, "y")
+      },
+      data: this.consolidateData(nextProps)
+    });
+  }
 
-    // each bar segment needs to know where it goes relative to the others, hence y0 y1
-    _.forEach(localCopyOfData, (bar) => {
-      let y0 = 0;
-      bar.segments = _.map(color.domain(), (segmentName) => {
+  createStringMap(originalProps, axis) {
+    const props = _.cloneDeep(originalProps);
+    // if categories exist and are strings, create a map using only those strings
+    // dont alter the order.
+    const categories = props.categories ?
+      (props.categories[axis] || props.categories) : undefined;
+    if (categories && this.containsStrings(categories)) {
+      return _.zipObject(_.map(categories, (tick, index) => {
+        return ["" + tick, index + 1];
+      }));
+    }
+    // collect strings from props.data
+    if (props.data) {
+      const data = _.isArray(props.data) ? _.flattenDeep(props.data) : props.data;
+      // create a unique, sorted set of strings
+      const stringData = _.chain(data)
+        .pluck(axis)
+        .map((datum) => {
+          return _.isString(datum) ? datum : null;
+        })
+        .compact()
+        .uniq()
+        .sort()
+        .value();
+
+      return _.isEmpty(stringData) ?
+        null :
+        _.zipObject(_.map(stringData, (string, index) => {
+          return [string, index + 1];
+        }));
+    }
+    else {
+      return {
+        x: null,
+        y: null
+      };
+    }
+  }
+
+  containsStrings(collection) {
+    return _.some(collection, function (item) {
+      return _.isString(item);
+    })
+  }
+
+  consolidateData(originalProps) {
+    const props = _.cloneDeep(originalProps);
+    if (props.data) {
+      const dataFromProps = _.isArray(props.data[0]) ? props.data : [props.data];
+      return _.map(dataFromProps, (dataset, index) => {
         return {
-          segmentName,
-          y0,
-          y1: y0 += +bar[segmentName]
+          attrs: this._getAttributes(props, index),
+          data: _.map(dataset, (data) => {
+            return _.merge(data, {
+              // map string data to numeric values, and add names
+              x: _.isString(data.x) ? stringMap.x[data.x] : data.x,
+              xName: _.isString(data.x) ? data.x : undefined,
+              y: _.isString(data.y) ? stringMap.y[data.y] : data.y,
+              yName: _.isString(data.y) ? data.y : undefined
+            });
+          })
         };
       });
-      bar.total = bar.segments[bar.segments.length - 1].y1;
-    });
+    } else {
+      return [{
+        attrs: {},
+        data: []
+      }];
+    }
+  }
 
-    /* width / categories = x.rangeBand */
-    const x = d3.scale.ordinal()
-      .rangeRoundBands([0, this.props.width - this.props.totalReductionInX], this.props.barPadding)
-      .domain(_.map(localCopyOfData, (bar) => {
-        return bar.label;
-      }));
+  _getAttributes(props, index) {
+    // type is y or data
+    const attributes = props.dataAttributes && props.dataAttributes[index] ?
+      props.dataAttributes[index] : props.dataAttributes;
+    const requiredAttributes = {
+      name: attributes && attributes.name ? attributes.name : "data-" + index,
+    };
+    return _.merge(requiredAttributes, attributes);
+  }
 
-    const y = d3.scale.linear()
-      .rangeRound([this.props.height - this.props.totalReductionInY, 0])
-      .domain([0, d3.max(localCopyOfData, (bar) => {
-        return bar.total;
-      })]);
+  getStyles() {
+    return _.merge({
+      borderColor: "transparent",
+      borderWidth: 0,
+      color: "#756f6a",
+      opacity: 1,
+      margin: 20,
+      width: 500,
+      height: 500,
+      fontFamily: "Helvetica",
+      fontSize: 10,
+      textAnchor: "middle"
+    }, this.props.style);
+  }
 
-    // localCopyOfData.sort((a, b) => {
-    //    return b.total - a.total;
-    // });
+  getScale(axis) {
+    const scale = this.props.scale[axis] ? this.props.scale[axis]().copy() :
+      this.props.scale().copy();
+    const range = this.getRange(axis);
+    const domain = this.getDomain(axis);
+    scale.range(range);
+    scale.domain(domain);
+    // hacky check for identity scale
+    if (_.difference(scale.range(), range).length !== 0) {
+      // identity scale, reset the domain and range
+      scale.range(range);
+      scale.domain(range);
+    }
+    return scale;
+  }
 
-    return _.map(localCopyOfData, (bar, i) => {
-      const scales = {
-        color,
-        x,
-        y
-      };
+  getRange(axis) {
+    if (this.props.range) {
+      return this.props.range[axis] ? this.props.range[axis] : this.props.range;
+    }
+    // if the range is not given in props, calculate it from width, height and margin
+    const style = this.getStyles();
+    return axis === "x" ?
+      [style.margin, style.width - style.margin] :
+      [style.height - style.margin, style.margin];
+  }
 
-      return (
-        <g
-          key={i}
-          className={"segmentGroup"}
-          transform={"translate(" + x(bar.label) + ",0)"}>
-          {this.props.makeSegments(bar.segments, scales)}
-        </g>
+  getDomain(axis) {
+    if (this.props.domain) {
+      return this.props.domain[axis] || this.props.domain;
+    } else if (this.props.data) {
+      return this._getDomainFromData(axis);
+    } else {
+      return this._getDomainFromScale(axis);
+    }
+  }
+
+  // helper method for getDomain
+  _getDomainFromScale(axis) {
+    // The scale will never be undefined due to default props
+    const scaleDomain = this.props.scale[axis] ? this.props.scale[axis]().domain() :
+      this.props.scale().domain();
+
+    // Warn when particular types of scales need more information to produce meaningful lines
+    // if (_.isDate(scaleDomain[0])) {
+    //   log.warn("please specify a domain or data when using time scales");
+    // } else if (scaleDomain.length === 0) {
+    //   log.warn("please specify a domain or data when using ordinal or quantile scales");
+    // } else if (scaleDomain.length === 1) {
+    //   log.warn("please specify a domain or data when using a threshold scale");
+    // }
+    return scaleDomain;
+  }
+
+  // helper method for getDomain
+  _getDomainFromData(axis) {
+    // if a sensible string map exists, return the minimum and maximum values
+    // offset by the tick margin value
+    if (!!this.state.stringMap[axis]) {
+      const mapValues = _.values(this.state.stringMap[axis]);
+      const margin = this.props.barMargin;
+      return [_.min(mapValues) - margin, _.max(mapValues) + margin];
+    } else {
+      // find the global min and max
+      const allData =  _.flatten(_.pluck(this.state.data, "data"));
+      const min = _.min(_.pluck(allData, axis));
+      const max = _.max(_.pluck(allData, axis));
+      // find the cumulative max for stacked chart types
+      // this is only sensible for the y domain
+      const cumulativeMax = (this.props.stacked && axis === "y") ?
+        _.reduce(this.state.data, (memo, dataset) => {
+          return memo + (_.max(_.pluck(dataset.data, axis)) - _.min(_.pluck(dataset.data, axis)));
+        }, 0) : -Infinity
+      return [min, _.max([max, cumulativeMax])];
+    }
+  }
+
+  // getBarPoints() {
+  //   const axis = "x"; // bar charts should always start from the independent variable
+  //   const scale = this.getScale(axis);
+  //   // if barPoints are defined in props, and dont contain strings, just return them
+  //   if (this.props.barPoints && !this.containsStrings(this.props.barPoints)) {
+  //     return this.props.barPoints;
+  //   } else if (!!this.state.stringMap[axis]) {
+  //     // category values should have one tick of padding on either side
+  //     const barPoints = this.props.barPoints ?
+  //       _.map(this.props.barPoints, (bar) => this.state.stringMap[axis][bar]) :
+  //       _.values(this.state.stringMap[axis]);
+  //     const margin = this.props.barMargin;
+  //     return [
+  //       _.min(barPoints) - margin,
+  //       ...barPoints,
+  //       _.max(barPoints) + margin
+  //     ];
+  //   } else if (_.isFunction(scale.ticks)) {
+  //     const bars = scale.ticks(this.props.barCount);
+  //     return _.without(bars, 0);
+  //   } else {
+  //     return scale.domain();
+  //   }
+  // }
+
+  getBarWidth() {
+    return this.props.barWidth;
+    // const seriesCount = this.state.data.length;
+    // const dataCount = _.max(_.map(_.pluck(this.state.data, "data"), (dataset) => {
+    //   return _.pluck(dataset, "x").length
+    // }));
+    // const barCount = this.props.stacked ? dataCount : dataCount * seriesCount;
+    // const allowedLength = this.getRange("x");
+    // const outerPadding = (dataCount - 2) * this.props.outerPadding;
+    // const innerPadding = (seriesCount - 2) * this.props.innerPadding
+    // const totalPadding = this.props.stacked ? outerPadding : outerPadding + innerPadding;
+    // const maxWidth = allowedLength - totalPadding / (barCount);
+    // return _.min([this.props.width, maxWidth]);
+  }
+
+  getBarPath(x, y0, y1, width) {
+    const size = width / 2;
+    return "M " + (x - size) + "," + y0 + " " +
+      "L " + (x - size) + "," + y1 +
+      "L " + (x + size) + "," + y1 +
+      "L " + (x + size) + "," + y0 +
+      "L " + (x - size) + "," + y0;
+  }
+
+  _adjustX(x, index, barIndex) {
+
+    if (this.state.stringMap.x === null) {
+      // don't adjust x if the x axis is numeric
+      return x;
+    }
+    const center = this.state.data.length % 2 === 0 ?
+      this.state.data.length / 2 : (this.state.data.length - 1) / 2;
+    const centerOffset = index - center;
+    return x + (centerOffset * 0.1);
+  }
+
+  _adjustY0(y, index, barIndex) {
+    if (index === 0) {
+      return y;
+    }
+    const previousDataSet = this.state.data[index - 1];
+    const previousBar = previousDataSet.data[barIndex];
+    return previousBar.y;
+  }
+
+  _adjustY1(y, index, barIndex) {
+    if (index === 0) {
+      return y;
+    }
+    const previousDataSet = this.state.data[index - 1];
+    const previousBar = previousDataSet.data[barIndex]
+    return previousBar.y + y;
+  }
+
+  getBarElements(dataset, style, index) {
+    return _.map(dataset.data, (data, barIndex) => {
+      const minY = _.min(this.getDomain("y"));
+      const y0 = this.props.stacked ? this._adjustY0(minY, index, barIndex) : minY;
+      const y1 = this.props.stacked ? this._adjustY1(data.y, index, barIndex) : data.y;
+      const x = this.props.stacked ? data.x : this._adjustX(data.x, index, barIndex);
+      const scaledX = this.getScale("x").call(this, x);
+      const scaledY0 = this.getScale("y").call(this, y0);
+      const scaledY1 = this.getScale("y").call(this, y1);
+      const width = this.getBarWidth();
+      const path = this.getBarPath(scaledX, scaledY0, scaledY1, width);
+      const pathElement = (
+        <path
+          d={path}
+          fill={dataset.attrs.color || style.color || "blue"}
+          key={"series-" + index + "-bar-" + barIndex}
+          opacity={dataset.attrs.opacity || style.opacity || 1}
+          shapeRendering="optimizeSpeed"
+          stroke="transparent"
+          strokeWidth={0}>
+        </path>
       );
+      return pathElement;
     });
   }
 
-  drawBars() {
-    return _.map(this.props.data, (bar, i) => {
-      return (
-        <rect
-          key={i}
-          width={20}
-          height={bar}
-          x={i * 30}
-          y={this.props.height - bar}/>
-      );
+  plotDataPoints() {
+    return _.map(this.state.data, (dataset, index) => {
+      const style = this.getStyles();
+      return this.getBarElements(dataset, style, index);
     });
   }
 
-  // offsets and squishing to fit inside axis
   render() {
-    if (this.props.svg) {
+    if (this.props.containerElement === "svg") {
       return (
-        <svg width={this.props.width} height={this.props.height}>
-          <g transform={"translate(" + this.props.translateX + "," + this.props.translateY + ")"}>
-            { _.isObject(this.props.data[0]) ? this.drawStackedBars() : this.drawBars() }
-          </g>
-        </svg>
+        <svg style={this.getStyles()}>{this.plotDataPoints()}</svg>
       );
     }
-
     return (
-      <g transform={"translate(" + this.props.translateX + "," + this.props.translateY + ")"}>
-        { _.isObject(this.props.data[0]) ? this.drawStackedBars() : this.drawBars() }
-      </g>
+      <g style={this.getStyles()}>{this.plotDataPoints()}</g>
     );
   }
 }
 
 VictoryBar.propTypes = {
-  barPadding: React.PropTypes.number,
-  data: React.PropTypes.array,
-  svg: React.PropTypes.bool,
-  width: React.PropTypes.number,
-  height: React.PropTypes.number,
-  makeSegments: React.PropTypes.func,
-  colorCategories: React.PropTypes.array,
-  translateX: React.PropTypes.number,
-  translateY: React.PropTypes.number,
-  totalReductionInY: React.PropTypes.number,
-  totalReductionInX: React.PropTypes.number
+  data: React.PropTypes.oneOfType([ // maybe this should just be "node"
+    React.PropTypes.arrayOf(
+      React.PropTypes.shape({
+        x: React.PropTypes.any,
+        y: React.PropTypes.any
+      })
+    ),
+    React.PropTypes.arrayOf(
+      React.PropTypes.arrayOf(
+        React.PropTypes.shape({
+          x: React.PropTypes.any,
+          y: React.PropTypes.any
+        })
+      )
+    )
+  ]),
+  dataAttributes: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.arrayOf(React.PropTypes.object)
+  ]),
+  categories: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.shape({
+      x: React.PropTypes.array,
+      y: React.PropTypes.array
+    })
+  ]),
+  domain: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.shape({
+      x: React.PropTypes.array,
+      y: React.PropTypes.array
+    })
+  ]),
+  range: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.shape({
+      x: React.PropTypes.array,
+      y: React.PropTypes.array
+    })
+  ]),
+  scale: React.PropTypes.oneOfType([
+    React.PropTypes.func,
+    React.PropTypes.shape({
+      x: React.PropTypes.func,
+      y: React.PropTypes.func
+    })
+  ]),
+  orientation: React.PropTypes.oneOf(["top", "bottom", "left", "right"]),
+  barMargin: React.PropTypes.number,
+  innerPadding: React.PropTypes.number,
+  outerPadding: React.PropTypes.number,
+  barWidth: React.PropTypes.number,
+  animate: React.PropTypes.bool,
+  stacked: React.PropTypes.bool,
+  style: React.PropTypes.node,
+  labelPadding: React.PropTypes.number,
+  showLabels: React.PropTypes.bool,
+  containerElement: React.PropTypes.oneOf(["g", "svg"])
 };
 
 VictoryBar.defaultProps = {
-  barPadding: 0.1,
-  data: [10, 30, 50, 80, 110],
-  svg: true,
-  width: 800,
-  height: 600,
-  makeSegments: (segments, scales) => {
-    return _.map(segments, (segment, i) => {
-      return (
-        <rect
-          key={i}
-          fill={scales.color(segment.segmentName)}
-          width={scales.x.rangeBand()}
-          height={scales.y(segment.y0) - scales.y(segment.y1)}
-          y={scales.y(segment.y1)}/>
-      );
-    });
-  },
-  colorCategories: [
-    "#98abc5",
-    "#8a89a6",
-    "#7b6888",
-    "#6b486b",
-    "#a05d56",
-    "#d0743c",
-    "#ff8c00"
-  ],
-  totalReductionInX: 0,
-  totalReductionInY: 0,
-  translateX: 0,
-  translateY: 0
+  animate: false,
+  stacked: false,
+  barWidth: 8,
+  barMargin: 0.5,
+  innerPadding: 2,
+  outerPadding: 4,
+  scale: () => d3.scale.linear(),
+  showLabels: true,
+  containerElement: "svg"
 };
 
 export default VictoryBar;

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -198,7 +198,7 @@ class VBar extends React.Component {
     // offset by the bar offset value
     if (this.stringMap[axis] !== null) {
       const mapValues = _.values(this.stringMap[axis]);
-      const offset = props.categoryOffset;
+      const offset = props.categoryPadding;
       return [_.min(mapValues) - offset, _.max(mapValues) + offset];
     } else {
       // find the global min and max
@@ -340,7 +340,22 @@ class VictoryBar extends React.Component {
 }
 
 const propTypes = {
-  data: React.PropTypes.oneOfType([ // maybe this should just be "node"
+  /**
+   * The data prop specifies the data to be plotted. Data should be in the form of an array
+   * of data points, or an array of arrays of data points for multiple datasets.
+   * Each data point should be an object with x and y properties.
+   * @exampes [
+   *   {x: new Date(1982, 1, 1), y: 125},
+   *   {x: new Date(1987, 1, 1), y: 257},
+   *   {x: new Date(1993, 1, 1), y: 345}
+   * ],
+   * [
+   *   [{x: 5, y: 3}, {x: 4, y: 2}, {x: 3, y: 1}],
+   *   [{x: 1, y: 2}, {x: 2, y: 3}, {x: 3, y: 4}],
+   *   [{x: 1, y: 2}, {x: 2, y: 2}, {x: 3, y: 2}]
+   * ]
+   */
+  data: React.PropTypes.oneOfType([
     React.PropTypes.arrayOf(
       React.PropTypes.shape({
         x: React.PropTypes.any,
@@ -356,11 +371,34 @@ const propTypes = {
       )
     )
   ]),
+  /**
+   * The dataAttributes prop describes how a data set should be styled.
+   * This prop can be given as an object, or an array of objects. If this prop is
+   * given as an array of objects, the properties of each object in the array will
+   * be applied to the data points in the corresponding array of the data prop.
+   * @exampes {color: "blue", opacity: 0.6},
+   * [{color: "red"}, {color: "orange"}]
+   */
   dataAttributes: React.PropTypes.oneOfType([
     React.PropTypes.object,
     React.PropTypes.arrayOf(React.PropTypes.object)
   ]),
+  /**
+   * The categories prop specifies the categories for a bar chart. This prop should
+   * be given as an array of string values, numeric values, or arrays. When this prop is
+   * given as an array of arrays, the minimum and maximum values of the arrays define range bands,
+   * allowing numeric data to be grouped into segments.
+   * @example ["dogs", "cats", "mice"], [[0, 5], [5, 10], [10, 15]]
+   */
   categories: React.PropTypes.array,
+  /**
+   * The domain prop describes the range of values your bar chart will cover. This prop can be
+   * given as a array of the minimum and maximum expected values for your bar chart,
+   * or as an object that specifies separate arrays for x and y.
+   * If this prop is not provided, a domain will be calculated from data, or other
+   * available information.
+   * @exampes [-1, 1], {x: [0, 100], y: [0, 1]}
+   */
   domain: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.shape({
@@ -368,6 +406,15 @@ const propTypes = {
       y: React.PropTypes.array
     })
   ]),
+  /**
+   * The range prop describes the range of pixels your bar chart will cover. This prop can be
+   * given as a array of the minimum and maximum expected values for your bar chart,
+   * or as an object that specifies separate arrays for x and y.
+   * If this prop is not provided, a range will be calculated based on the height,
+   * width, and margin provided in the style prop, or in default styles. It is usually
+   * a good idea to let the chart component calculate its own range.
+   * @exampes [0, 500], {x: [0, 500], y: [500, 300]}
+   */
   range: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.shape({
@@ -375,6 +422,11 @@ const propTypes = {
       y: React.PropTypes.array
     })
   ]),
+  /**
+   * The scale prop determines which scales your chart should use. This prop can be
+   * given as a function, or as an object that specifies separate functions for x and y.
+   * @exampes () => d3.time.scale(), {x: () => d3.scale.linear(), y: () => d3.scale.log()}
+   */
   scale: React.PropTypes.oneOfType([
     React.PropTypes.func,
     React.PropTypes.shape({
@@ -382,12 +434,38 @@ const propTypes = {
       y: React.PropTypes.func
     })
   ]),
-  categoryOffset: React.PropTypes.number,
+  categoryPadding: React.PropTypes.number,
+  /**
+   * The barPadding prop specifies the padding in number of pixels between bars
+   * rendered in a bar chart.
+   */
   barPadding: React.PropTypes.number,
+  /**
+   * The barWidth prop specifies the width in number of pixels for bars rendered in a bar chart.
+   */
   barWidth: React.PropTypes.number,
+  /**
+   * The animate prop determines whether the chart should animate with changing data.
+   */
   animate: React.PropTypes.bool,
+  /**
+   * The stacked prop determines whether the chart should consist of stacked bars.
+   * When this prop is set to false, grouped bars will be rendered instead.
+   */
   stacked: React.PropTypes.bool,
+  /**
+   * The style prop specifies styles for your chart. VictoryBar relies on Radium,
+   * so valid Radium style objects should work for this prop, however height, width, and margin
+   * are used to calculate range, and need to be expressed as a number of pixels
+   * @example {width: 500, height: 300}
+   */
   style: React.PropTypes.node,
+  /**
+   * The containerElement prop specifies which element the compnent will render.
+   * For standalone bars, the containerElement prop should be "svg". If you need to
+   * compose bar with other chart components, the containerElement prop should
+   * be "g", and will need to be rendered within an svg tag.
+   */
   containerElement: React.PropTypes.oneOf(["g", "svg"])
 };
 
@@ -396,7 +474,7 @@ const defaultProps = {
   stacked: false,
   barWidth: 8,
   barPadding: 6,
-  categoryOffset: 0.5,
+  categoryPadding: 0.5,
   scale: () => d3.scale.linear(),
   containerElement: "svg"
 };

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -272,7 +272,8 @@ class VBar extends React.Component {
   }
 
   getBarElements(dataset, index) {
-    return _.map(dataset.data, (data, barIndex) => {
+    // create one path for all bars of the same data series
+    const path = _.reduce(dataset.data, (memo, data, barIndex) => {
       const minY = _.min(this.domain.y);
       const yOffset = this.getYOffset(minY, index, barIndex);
       const y0 = this.props.stacked ? yOffset : minY;
@@ -281,20 +282,21 @@ class VBar extends React.Component {
       const scaledX = this.scale.x.call(this, x);
       const scaledY0 = this.scale.y.call(this, y0);
       const scaledY1 = this.scale.y.call(this, y1);
-      const path = scaledX ? this.getBarPath(scaledX, scaledY0, scaledY1) : undefined;
-      const pathElement = (
-        <path
-          d={path}
-          fill={dataset.attrs.color || this.style.color || "blue"}
-          key={"series-" + index + "-bar-" + barIndex}
-          opacity={dataset.attrs.opacity || this.style.opacity || 1}
-          shapeRendering="optimizeSpeed"
-          stroke="transparent"
-          strokeWidth={0}>
-        </path>
-      );
-      return pathElement;
-    });
+      const partialPath = scaledX ? this.getBarPath(scaledX, scaledY0, scaledY1) : "";
+      return memo + partialPath;
+    }, "");
+
+    return (
+      <path
+        d={path}
+        fill={dataset.attrs.color || this.style.color || "blue"}
+        key={"series-" + index}
+        opacity={dataset.attrs.opacity || this.style.opacity || 1}
+        shapeRendering="optimizeSpeed"
+        stroke="transparent"
+        strokeWidth={0}>
+      </path>
+    );
   }
 
   plotDataPoints() {
@@ -329,6 +331,7 @@ class VictoryBar extends React.Component {
                 stacked={this.props.stacked}
                 scale={this.props.scale}
                 animate={this.props.animate}
+                categoryOffset={this.props.categoryOffset}
                 containerElement={this.props.containerElement}/>
             );
           }}

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -272,7 +272,7 @@ class VBar extends React.Component {
     }, 0);
   }
 
-  getBarElements(dataset, style, index) {
+  getBarElements(dataset, index) {
     return _.map(dataset.data, (data, barIndex) => {
       const minY = _.min(this.domain.y);
       const yOffset = this.getYOffset(minY, index, barIndex);
@@ -286,9 +286,9 @@ class VBar extends React.Component {
       const pathElement = (
         <path
           d={path}
-          fill={dataset.attrs.color || style.color || "blue"}
+          fill={data.color || dataset.attrs.color || this.styles.color || "blue"}
           key={"series-" + index + "-bar-" + barIndex}
-          opacity={dataset.attrs.opacity || style.opacity || 1}
+          opacity={dataset.attrs.opacity || this.styles.opacity || 1}
           shapeRendering="optimizeSpeed"
           stroke="transparent"
           strokeWidth={0}>
@@ -300,8 +300,7 @@ class VBar extends React.Component {
 
   plotDataPoints() {
     return _.map(this.datasets, (dataset, index) => {
-      const style = this.styles;
-      return this.getBarElements(dataset, style, index);
+      return this.getBarElements(dataset, index);
     });
   }
 
@@ -319,22 +318,23 @@ class VBar extends React.Component {
 
 @Radium
 class VictoryBar extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   render() {
     if (this.props.animate) {
+      const propsToAnimate = {
+        data: this.props.data,
+        dataAttributes: this.props.dataAttributes,
+        style: this.props.style,
+        barWidth: this.props.barWidth,
+        barPadding: this.props.barPadding,
+        categoryOffset: this.props.categoryOffset
+      };
       return (
-        <VictoryAnimation data={this.props}>
+        <VictoryAnimation data={propsToAnimate}>
           {(props) => {
             return (
               <VBar
-                {...props}
-                stacked={this.props.stacked}
-                scale={this.props.scale}
-                animate={this.props.animate}
-                containerElement={this.props.containerElement}/>
+                {...this.props}
+                {...props}/>
             );
           }}
         </VictoryAnimation>

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -8,14 +8,14 @@ import {VictoryAnimation} from "victory-animation";
 class VBar extends React.Component {
   constructor(props) {
     super(props);
-    this.getCaluclatedValues(props);
+    this.getCalculatedValues(props);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.getCaluclatedValues(nextProps);
+    this.getCalculatedValues(nextProps);
   }
 
-  getCaluclatedValues(props) {
+  getCalculatedValues(props) {
     this.styles = this.getStyles(props);
     this.stringMap = {
       x: this.createStringMap(props, "x"),

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -16,7 +16,7 @@ class VBar extends React.Component {
   }
 
   getCalculatedValues(props) {
-    this.styles = this.getStyles(props);
+    this.style = this.getStyles(props);
     this.stringMap = {
       x: this.createStringMap(props, "x"),
       y: this.createStringMap(props, "y")
@@ -151,25 +151,21 @@ class VBar extends React.Component {
     }
     // if the range is not given in props, calculate it from width, height and margin
     return axis === "x" ?
-      [this.styles.margin, this.styles.width - this.styles.margin] :
-      [this.styles.height - this.styles.margin, this.styles.margin];
+      [this.style.margin, this.style.width - this.style.margin] :
+      [this.style.height - this.style.margin, this.style.margin];
   }
 
   getDomain(props, axis) {
     const categoryDomain = this._getDomainFromCategories(props, axis);
-    let domain;
     if (props.domain) {
-      domain = props.domain[axis] || props.domain;
+      return props.domain[axis] || props.domain;
     } else if (categoryDomain) {
-      domain = categoryDomain;
+      return categoryDomain;
     } else if (props.data) {
-      domain = this._getDomainFromData(props, axis);
+      return this._getDomainFromData(props, axis);
     } else {
-      domain = this._getDomainFromScale(props, axis);
+      return this._getDomainFromScale(props, axis);
     }
-    const offset = props.categoryOffset;
-    return axis === "x" ? [_.min(domain) - offset, _.max(domain) + offset] : domain;
-
   }
 
   _getDomainFromCategories(props, axis) {
@@ -202,7 +198,8 @@ class VBar extends React.Component {
     // offset by the bar offset value
     if (this.stringMap[axis] !== null) {
       const mapValues = _.values(this.stringMap[axis]);
-      return [_.min(mapValues), _.max(mapValues)];
+      const offset = props.categoryOffset;
+      return [_.min(mapValues) - offset, _.max(mapValues) + offset];
     } else {
       // find the global min and max
       const allData = _.flatten(_.pluck(this.datasets, "data"));
@@ -219,9 +216,9 @@ class VBar extends React.Component {
     }
   }
 
-  getBarWidth() {
+  getBarWidth(props) {
     // todo calculate / enforce max width
-    return this.props.barWidth;
+    return props.barWidth;
   }
 
   getBarPath(x, y0, y1) {
@@ -288,9 +285,9 @@ class VBar extends React.Component {
       const pathElement = (
         <path
           d={path}
-          fill={data.color || dataset.attrs.color || this.styles.color || "blue"}
+          fill={dataset.attrs.color || this.style.color || "blue"}
           key={"series-" + index + "-bar-" + barIndex}
-          opacity={dataset.attrs.opacity || this.styles.opacity || 1}
+          opacity={dataset.attrs.opacity || this.style.opacity || 1}
           shapeRendering="optimizeSpeed"
           stroke="transparent"
           strokeWidth={0}>
@@ -309,33 +306,30 @@ class VBar extends React.Component {
   render() {
     if (this.props.containerElement === "svg") {
       return (
-        <svg style={this.styles}>{this.plotDataPoints()}</svg>
+        <svg style={this.style}>{this.plotDataPoints()}</svg>
       );
     }
     return (
-      <g style={this.styles}>{this.plotDataPoints()}</g>
+      <g style={this.style}>{this.plotDataPoints()}</g>
     );
   }
 }
 
 @Radium
 class VictoryBar extends React.Component {
+
   render() {
     if (this.props.animate) {
-      const propsToAnimate = {
-        data: this.props.data,
-        dataAttributes: this.props.dataAttributes,
-        style: this.props.style,
-        barWidth: this.props.barWidth,
-        barPadding: this.props.barPadding
-      };
       return (
-        <VictoryAnimation data={propsToAnimate}>
+        <VictoryAnimation data={this.props}>
           {(props) => {
             return (
               <VBar
-                {...this.props}
-                {...props}/>
+                {...props}
+                stacked={this.props.stacked}
+                scale={this.props.scale}
+                animate={this.props.animate}
+                containerElement={this.props.containerElement}/>
             );
           }}
         </VictoryAnimation>

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -258,7 +258,7 @@ class VBar extends React.Component {
       const bandCenter = _.isArray(xBand[0]) && (_.max(xBand[0]) + _.min(xBand[0])) / 2;
       return this.props.stacked ? bandCenter : bandCenter + (centerOffset * totalWidth);
     }
-    return this.props.stacked ? x  : x  + (centerOffset * totalWidth);
+    return this.props.stacked ? x : x + (centerOffset * totalWidth);
   }
 
   getYOffset(y, index, barIndex) {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -272,8 +272,7 @@ class VBar extends React.Component {
   }
 
   getBarElements(dataset, index) {
-    // create one path for all bars of the same data series
-    const path = _.reduce(dataset.data, (memo, data, barIndex) => {
+    return _.map(dataset.data, (data, barIndex) => {
       const minY = _.min(this.domain.y);
       const yOffset = this.getYOffset(minY, index, barIndex);
       const y0 = this.props.stacked ? yOffset : minY;
@@ -282,21 +281,20 @@ class VBar extends React.Component {
       const scaledX = this.scale.x.call(this, x);
       const scaledY0 = this.scale.y.call(this, y0);
       const scaledY1 = this.scale.y.call(this, y1);
-      const partialPath = scaledX ? this.getBarPath(scaledX, scaledY0, scaledY1) : "";
-      return memo + partialPath;
-    }, "");
-
-    return (
-      <path
-        d={path}
-        fill={dataset.attrs.color || this.style.color || "blue"}
-        key={"series-" + index}
-        opacity={dataset.attrs.opacity || this.style.opacity || 1}
-        shapeRendering="optimizeSpeed"
-        stroke="transparent"
-        strokeWidth={0}>
-      </path>
-    );
+      const path = scaledX ? this.getBarPath(scaledX, scaledY0, scaledY1) : undefined;
+      const pathElement = (
+        <path
+          d={path}
+          fill={dataset.attrs.color || this.style.color || "blue"}
+          key={"series-" + index + "-bar-" + barIndex}
+          opacity={dataset.attrs.opacity || this.style.opacity || 1}
+          shapeRendering="optimizeSpeed"
+          stroke="transparent"
+          strokeWidth={0}>
+        </path>
+      );
+      return pathElement;
+    });
   }
 
   plotDataPoints() {
@@ -331,7 +329,6 @@ class VictoryBar extends React.Component {
                 stacked={this.props.stacked}
                 scale={this.props.scale}
                 animate={this.props.animate}
-                categoryOffset={this.props.categoryOffset}
                 containerElement={this.props.containerElement}/>
             );
           }}

--- a/src/log.js
+++ b/src/log.js
@@ -1,0 +1,10 @@
+/* eslint-disable*/
+module.exports = {
+  warn: function (message) {
+    if (process.env.NODE_ENV !== "production") {
+      if (console && console.warn) {
+        console.warn(message);
+      }
+    }
+  }
+};


### PR DESCRIPTION
cc/ @colinmegill cc/ @kenwheeler 

This version of bar has changed a lot to make it more consistent with the other chart-like components
- no more ordinal scales! just a simple string -> value mapping, and then some math to make all the padding work out nicely.  I think there might be some polish left there for the non-stacked charts
- grouped or stacked bars with a flag 
- animating or static bars with a flag. @kenwheeler animation is very slow! I'm not sure whether I'm messing something up, or if I have too many svg nodes / tabs open in chrome
- categories prop that can take an array of strings or numbers to define single value categories (i.e. `["russia", "china", "india"]`) of an array of arrays to define range bands (i.e. `[[0, 2], [2, 4], [4, 6]]`) 

TODOS:
- [ ] support y-axis bars
- [ ] make a color picker
