### PR TITLE
Refactor api

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -68,11 +68,11 @@ class App extends React.Component {
           <VictoryBar
             data={this.state.numericBarData}
             dataAttributes={[
-              {color: "cornflowerblue"},
-              {color: "orange"},
-              {color: "greenyellow"},
-              {color: "gold"},
-              {color: "tomato"}
+              {fill: "cornflowerblue"},
+              {fill: "orange"},
+              {fill: "greenyellow"},
+              {fill: "gold"},
+              {fill: "tomato"}
             ]}
             categories={[[1, 3], [4, 7], [9, 11]]}
             containerElement="svg"
@@ -81,11 +81,11 @@ class App extends React.Component {
             <VictoryBar
             data={this.state.barData}
             dataAttributes={[
-              {color: "cornflowerblue"},
-              {color: "orange"},
-              {color: "greenyellow"},
-              {color: "gold"},
-              {color: "tomato"}
+              {fill: "cornflowerblue"},
+              {fill: "orange"},
+              {fill: "greenyellow"},
+              {fill: "gold"},
+              {fill: "tomato"}
             ]}
             stacked={true}
             containerElement="svg"

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -2,6 +2,7 @@
 /*global window:false*/
 import _ from "lodash";
 import React from "react";
+import ReactDOM from "react-dom";
 import {VictoryBar} from "../src/index";
 
 class App extends React.Component {
@@ -100,4 +101,4 @@ class App extends React.Component {
 
 const content = document.getElementById("content");
 
-React.render(<App/>, content);
+ReactDOM.render(<App/>, content);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/FormidableLabs/victory-bar",
   "scripts": {
-    "postinstall": "npm run build-lib",
+    "postinstall": "node -e \"require('fs').stat('lib', function(e,s){process.exit(e || !s.isDirectory() ? 1 : 0)})\" || npm run build-lib",
     "preversion": "npm run check",
     "version": "npm run clean && npm run build && git add -A dist",
     "clean-dist": "rimraf dist",
@@ -55,11 +55,11 @@
     "babel-core": "^5.5.8",
     "babel-loader": "^5.3.2",
     "d3": "^3.5.6",
-    "radium": "^0.13.4",
+    "radium": "^0.14.1",
     "rimraf": "^2.4.0",
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
-    "victory-animation": "^0.0.6",
+    "victory-animation": "^0.0.8",
     "webpack": "^1.10.0"
   },
   "devDependencies": {
@@ -86,7 +86,8 @@
     "mocha": "^2.2.5",
     "opener": "^1.4.1",
     "phantomjs": "^1.9.17",
-    "react": "0.13.x",
+    "react": "0.14.x",
+    "react-dom": "0.14.x",
     "react-hot-loader": "^1.2.8",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -462,7 +462,7 @@ const propTypes = {
    * The style prop specifies styles for your chart. VictoryBar relies on Radium,
    * so valid Radium style objects should work for this prop, however height, width, and margin
    * are used to calculate range, and need to be expressed as a number of pixels
-   * @example {width: 500, height: 300}
+   * @example {width: 500, height: 300, data: {fill: "red", opacity: 1, width: 8}}
    */
   style: React.PropTypes.object,
   /**

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -11,14 +11,15 @@ const styles = {
     height: 300,
     margin: 50
   },
-  bar: {
+  data: {
     width: 8,
     padding: 6,
     stroke: "transparent",
     strokeWidth: 0,
     fill: "#756f6a",
     opacity: 1
-  }
+  },
+  labels: {}
 };
 
 class VBar extends React.Component {
@@ -57,10 +58,11 @@ class VBar extends React.Component {
     if (!props.style) {
       return styles;
     }
-    const {bar, ...base} = props.style;
+    const {data, labels, ...base} = props.style;
     return {
       base: _.merge({}, styles.base, base),
-      bar: _.merge({}, styles.bar, bar)
+      data: _.merge({}, styles.data, data),
+      labels: _.merge({}, styles.labels, labels)
     };
   }
 
@@ -230,7 +232,7 @@ class VBar extends React.Component {
 
   getBarWidth() {
     // todo calculate / enforce max width
-    return this.style.bar.width;
+    return this.style.data.width;
   }
 
   getBarPath(x, y0, y1) {
@@ -256,8 +258,8 @@ class VBar extends React.Component {
     const center = this.datasets.length % 2 === 0 ?
       this.datasets.length / 2 : (this.datasets.length - 1) / 2;
     const centerOffset = index - center;
-    const totalWidth = this._pixelsToValue(this.style.bar.padding) +
-      this._pixelsToValue(this.style.bar.width);
+    const totalWidth = this._pixelsToValue(this.style.data.padding) +
+      this._pixelsToValue(this.style.data.width);
     if (this.props.categories && _.isArray(this.props.categories[0])) {
       // figure out which band this x value belongs to, and shift it to the
       // center of that band before calculating the usual offset
@@ -294,7 +296,7 @@ class VBar extends React.Component {
       const scaledY0 = this.scale.y.call(this, y0);
       const scaledY1 = this.scale.y.call(this, y1);
       const path = scaledX ? this.getBarPath(scaledX, scaledY0, scaledY1) : undefined;
-      const style = _.merge({}, this.style.bar, dataset.attrs, data);
+      const style = _.merge({}, this.style.data, dataset.attrs, data);
       const pathElement = (
         <path
           d={path}

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -5,6 +5,22 @@ import d3 from "d3";
 import log from "../log";
 import {VictoryAnimation} from "victory-animation";
 
+const styles = {
+  base: {
+    width: 500,
+    height: 300,
+    margin: 50
+  },
+  bar: {
+    width: 8,
+    padding: 6,
+    stroke: "transparent",
+    strokeWidth: 0,
+    fill: "#756f6a",
+    opacity: 1
+  }
+};
+
 class VBar extends React.Component {
   constructor(props) {
     super(props);
@@ -38,18 +54,14 @@ class VBar extends React.Component {
   }
 
   getStyles(props) {
-    return _.merge({
-      borderColor: "transparent",
-      borderWidth: 0,
-      color: "#756f6a",
-      opacity: 1,
-      margin: 20,
-      width: 500,
-      height: 300,
-      fontFamily: "Helvetica",
-      fontSize: 10,
-      textAnchor: "middle"
-    }, props.style);
+    if (!props.style) {
+      return styles;
+    }
+    const {bar, ...base} = props.style;
+    return {
+      base: _.merge({}, styles.base, base),
+      bar: _.merge({}, styles.bar, bar)
+    };
   }
 
   consolidateData(props) {
@@ -150,9 +162,10 @@ class VBar extends React.Component {
       return props.range[axis] ? props.range[axis] : props.range;
     }
     // if the range is not given in props, calculate it from width, height and margin
+    const style = this.style.base;
     return axis === "x" ?
-      [this.style.margin, this.style.width - this.style.margin] :
-      [this.style.height - this.style.margin, this.style.margin];
+      [style.margin, style.width - style.margin] :
+      [style.height - style.margin, style.margin];
   }
 
   getDomain(props, axis) {
@@ -215,9 +228,9 @@ class VBar extends React.Component {
     }
   }
 
-  getBarWidth(props) {
+  getBarWidth() {
     // todo calculate / enforce max width
-    return props.barWidth;
+    return this.style.bar.width;
   }
 
   getBarPath(x, y0, y1) {
@@ -243,8 +256,8 @@ class VBar extends React.Component {
     const center = this.datasets.length % 2 === 0 ?
       this.datasets.length / 2 : (this.datasets.length - 1) / 2;
     const centerOffset = index - center;
-    const totalWidth = this._pixelsToValue(this.props.barPadding) +
-      this._pixelsToValue(this.props.barWidth);
+    const totalWidth = this._pixelsToValue(this.style.bar.padding) +
+      this._pixelsToValue(this.style.bar.width);
     if (this.props.categories && _.isArray(this.props.categories[0])) {
       // figure out which band this x value belongs to, and shift it to the
       // center of that band before calculating the usual offset
@@ -281,15 +294,13 @@ class VBar extends React.Component {
       const scaledY0 = this.scale.y.call(this, y0);
       const scaledY1 = this.scale.y.call(this, y1);
       const path = scaledX ? this.getBarPath(scaledX, scaledY0, scaledY1) : undefined;
+      const style = _.merge({}, this.style.bar, dataset.attrs, data);
       const pathElement = (
         <path
           d={path}
-          fill={dataset.attrs.color || this.style.color || "blue"}
           key={"series-" + index + "-bar-" + barIndex}
-          opacity={dataset.attrs.opacity || this.style.opacity || 1}
           shapeRendering="optimizeSpeed"
-          stroke="transparent"
-          strokeWidth={0}>
+          style={style}>
         </path>
       );
       return pathElement;
@@ -305,11 +316,11 @@ class VBar extends React.Component {
   render() {
     if (this.props.containerElement === "svg") {
       return (
-        <svg style={this.style}>{this.plotDataPoints()}</svg>
+        <svg style={this.style.base}>{this.plotDataPoints()}</svg>
       );
     }
     return (
-      <g style={this.style}>{this.plotDataPoints()}</g>
+      <g style={this.style.base}>{this.plotDataPoints()}</g>
     );
   }
 }
@@ -434,15 +445,6 @@ const propTypes = {
     })
   ]),
   /**
-   * The barPadding prop specifies the padding in number of pixels between bars
-   * rendered in a bar chart.
-   */
-  barPadding: React.PropTypes.number,
-  /**
-   * The barWidth prop specifies the width in number of pixels for bars rendered in a bar chart.
-   */
-  barWidth: React.PropTypes.number,
-  /**
    * The animate prop specifies props for victory-animation to use. It this prop is
    * not given, the bar chart will not tween between changing data / style props.
    * Large datasets might animate slowly due to the inherent limits of svg rendering.
@@ -460,7 +462,7 @@ const propTypes = {
    * are used to calculate range, and need to be expressed as a number of pixels
    * @example {width: 500, height: 300}
    */
-  style: React.PropTypes.node,
+  style: React.PropTypes.object,
   /**
    * The containerElement prop specifies which element the compnent will render.
    * For standalone bars, the containerElement prop should be "svg". If you need to
@@ -472,8 +474,6 @@ const propTypes = {
 
 const defaultProps = {
   stacked: false,
-  barWidth: 8,
-  barPadding: 6,
   scale: d3.scale.linear(),
   containerElement: "svg"
 };


### PR DESCRIPTION
cc/ @exogen 

this PR standardizes the style prop to a more css-like object, and used the correct svg property name "fill" instead of "color".  Also adds space for labels scope on the style object for currently non-existent labels. 
