### PR TITLE
dont calculated a cumulative max for stacked data if there is just on…

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -91,7 +91,18 @@ class App extends React.Component {
             stacked={true}
             containerElement="svg"
             animate={{velocity: 0.02}}/>
-
+            <VictoryBar
+            data={[
+              {x: "a", y: 1},
+              {x: "b", y: 3},
+              {x: "c", y: 10},
+              {x: "d", y: 5}
+            ]}
+            dataAttributes={[
+              {fill: "cornflowerblue"}
+            ]}
+            stacked={true}
+            containerElement="svg"/>
 
         </p>
       </div>

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "rimraf": "^2.4.0",
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
-    "victory-animation": "^0.0.8",
+    "victory-animation": "^0.0.10",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -222,7 +222,7 @@ class VBar extends React.Component {
       // find the cumulative max for stacked chart types
       // this is only sensible for the y domain
       // TODO check assumption
-      const cumulativeMax = (props.stacked && axis === "y") ?
+      const cumulativeMax = (props.stacked && axis === "y" && this.datasets.length > 1) ?
         _.reduce(this.datasets, (memo, dataset) => {
           return memo + (_.max(_.pluck(dataset.data, axis)) - _.min(_.pluck(dataset.data, axis)));
         }, 0) : -Infinity;


### PR DESCRIPTION
…e dataset

cc/ @exogen 

quick fix prevents a cumulative max when stacked bar plots only have one dataset
