### PR TITLE
Add static build config

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
   <![endif]-->
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-  <title>Demo</title>
+  <title>Victory Bar</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 </head>

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -23,5 +23,9 @@ class Docs extends React.Component {
   }
 }
 
-const content = document.getElementById("content");
-ReactDOM.render(<Docs/>, content);
+if (typeof document !== "undefined") {
+  const content = document.getElementById("content");
+  ReactDOM.render(<Docs/>, content);  
+}
+
+export default Docs;

--- a/docs/static-index.jsx
+++ b/docs/static-index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+class Index extends React.Component {
+  render() {
+    return (
+      <html>
+        <head>
+          <meta dangerouslySetInnerHTML={{ __html: `<!--[if lt IE 9]>
+            <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv-printshiv.js"></script>
+          <![endif]-->` }} />
+          <meta charSet="utf-8" />
+          <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+          <title>Victory Bar</title>
+          <meta name="description" content="" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+          <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.css"/>
+          <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/theme/monokai.min.css"/>
+          <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.css"/>
+          <link href="https://fonts.googleapis.com/css?family=Karla:400,700,400italic" rel="stylesheet" type="text/css" />
+        </head>
+        <body>
+          <div dangerouslySetInnerHTML={{ __html: `<!--[if lt IE 8]>
+            <p class="browsehappy">You are using an <strong>outdated</strong> browser.
+            Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+          <![endif]-->` }} />
+          <div id="content" dangerouslySetInnerHTML={{ __html: this.props.content }} />
+          <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.js"></script>
+          <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/mode/javascript/javascript.min.js"></script>
+          <script src={this.props.bundle}></script>
+          <div dangerouslySetInnerHTML={{ __html: `<!--[if lt IE 9]>
+            <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.7/es5-shim.min.js"></script>
+            <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.7/es5-sham.min.js"></script>
+          <![endif]-->` }} />
+        </body>
+      </html>
+    );
+  }
+}
+
+module.exports = Index;

--- a/docs/static-render-entry.jsx
+++ b/docs/static-render-entry.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+
+import Docs from "./docs";
+import IndexTemplate from "./static-index";
+
+const Index = React.createFactory(IndexTemplate);
+const _renderIndex = (component) => `<!DOCTYPE html>${ReactDOMServer.renderToStaticMarkup(component)}`;
+
+/**
+ * Helper component that allows `static-site-generator-webpack-plugin` to render
+ * root component (`Docs`) as static HTML
+ *
+ * Output built to `/gh-pages/` 
+ */
+
+export default (locals, next) => {
+  const source = JSON.parse(locals.webpackStats.compilation.assets["stats.json"].source());
+  const bundle = source.assetsByChunkName.main;
+
+  const content = ReactDOMServer.renderToStaticMarkup(<Docs />);
+  const html = _renderIndex(new Index({
+    content: content,
+    bundle: bundle
+  }));
+
+  next(null, html)
+};

--- a/docs/theme.js
+++ b/docs/theme.js
@@ -112,7 +112,7 @@ export default {
    */
   '.Container': {
     margin: '0 auto',
-    maxWidth: 960,
+    maxWidth: "960px",
     paddingLeft: '1em',
     paddingRight: '1em'
   },

--- a/docs/webpack.config.static.js
+++ b/docs/webpack.config.static.js
@@ -1,0 +1,33 @@
+var CleanPlugin = require("clean-webpack-plugin");
+var path = require("path");
+var StaticSiteGeneratorPlugin = require("static-site-generator-webpack-plugin");
+var StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
+
+var base = require("./webpack.config.dev.js");
+
+var OUTPUT_DIR = "gh-pages";
+
+// All routes we want to static-render--in this case, just the index page:
+var routes = [
+  ""
+];
+
+module.exports = {
+  entry: {
+    main: "./docs/static-render-entry.jsx"
+  },
+  output: {
+    path: path.join(__dirname, "../" + OUTPUT_DIR),
+    filename: "main.[hash].js",
+    libraryTarget: "umd" // Needs to be universal for `static-site-generator-webpack-plugin` to work
+  },
+  resolve: base.resolve,
+  module: base.module,
+  plugins: [
+    new CleanPlugin([ "../" + OUTPUT_DIR ]),
+    new StatsWriterPlugin({
+      filename: "stats.json"
+    }),
+    new StaticSiteGeneratorPlugin("main", routes)
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "check": "npm run lint && npm run test",
     "check-ci": "npm run lint && npm run test-ci",
     "check-cov": "npm run lint && npm run test-cov",
-    "check-dev": "npm run lint && npm run test-dev"
+    "check-dev": "npm run lint && npm run test-dev",
+    "build-static": "webpack --config docs/webpack.config.static.js --progress",
+    "push-gh-pages": "git subtree push --prefix gh-pages origin gh-pages"
   },
   "dependencies": {
     "babel": "^5.5.8",
@@ -70,11 +72,13 @@
   "devDependencies": {
     "babel-eslint": "^3.1.25",
     "chai": "^3.2.0",
+    "clean-webpack-plugin": "^0.1.4",
     "ecology": "git+https://github.com/formidablelabs/ecology#master",
     "eslint": "^0.24.1",
     "eslint-config-defaults": "^3.0.3",
     "eslint-plugin-filenames": "^0.1.1",
     "eslint-plugin-react": "^2.6.4",
+    "file-loader": "^0.8.4",
     "isparta-loader": "^0.2.0",
     "json-loader": "^0.5.3",
     "karma": "^0.12.37",
@@ -95,11 +99,13 @@
     "phantomjs": "^1.9.17",
     "raw-loader": "^0.5.1",
     "react": "0.14.x",
-    "react-dom": "0.14.x",
     "react-docgen": "^2.4.0",
+    "react-dom": "0.14.x",
     "react-hot-loader": "^1.2.8",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",
-    "webpack-dev-server": "^1.10.0"
+    "static-site-generator-webpack-plugin": "^1.2.0",
+    "webpack-dev-server": "^1.10.0",
+    "webpack-stats-plugin": "^0.1.1"
   }
 }


### PR DESCRIPTION
This adds config for building static demo assets, with the workflow we've come to know and love:

```
// Write and commit your main code, and then
npm run build-static
git add gh-pages
git commit gh-pages -m "Add gh-pages content" // or whatever
npm run push-gh-pages // Subtree push to root of `gh-pages` branch on remote
```

Just pushed, and here's victory-bar: http://projects.formidablelabs.com/victory-bar/

/cc @boygirl @kstrack-grose 
