### PR TITLE
auto color generator

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -81,13 +81,7 @@ class App extends React.Component {
 
             <VictoryBar
             data={this.state.barData}
-            dataAttributes={[
-              {fill: "cornflowerblue"},
-              {fill: "orange"},
-              {fill: "greenyellow"},
-              {fill: "gold"},
-              {fill: "tomato"}
-            ]}
+            colorScale={"yellowBlue"}
             categoryLabels={["one", "two", "three"]}
             stacked
             animate={{velocity: 0.02}}/>

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "victory-animation": "^0.0.10",
+    "victory-util": "git+https://github.com/formidablelabs/victory-util#feat/colors",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "victory-animation": "^0.0.10",
-    "victory-util": "git+https://github.com/formidablelabs/victory-util#feat/colors",
+    "victory-util": "git+https://github.com/formidablelabs/victory-util#master",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -120,7 +120,7 @@ export default class VictoryBar extends React.Component {
     colorScale: React.PropTypes.oneOfType([
       React.PropTypes.arrayOf(React.PropTypes.string),
       React.PropTypes.oneOf([
-        "victory", "grayscale", "red", "bluePurple", "yellowBlue"
+        "victory", "gray", "red", "bluePurple", "yellowBlue"
       ])
     ]),
     /**

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -3,6 +3,7 @@ import Radium from "radium";
 import _ from "lodash";
 import d3 from "d3";
 import {VictoryAnimation} from "victory-animation";
+import Util from "../../../victory-util/src/index";
 
 const styles = {
   parent: {
@@ -267,9 +268,8 @@ class VBar extends React.Component {
   _getAttributes(props, index) {
     let attributes = props.dataAttributes && props.dataAttributes[index] ?
       props.dataAttributes[index] : props.dataAttributes;
-    // see if attributes as fill; if it does not, add fill as randomly
-    // generated. see what's going on here to figure out how to get to fill
-    attributes ? attributes.fill = attributes.fill || this.getColor() :
+    // note: getColor will be replaced by Util.style.grayscaleColors
+    attributes ? attributes.fill = attributes.fill || getColor("bar") :
       attributes = {fill: this.getColor()};
 
     const requiredAttributes = {
@@ -278,8 +278,11 @@ class VBar extends React.Component {
     return _.merge(requiredAttributes, attributes);
   }
 
-  getColor() {
-    return "#9f9f9f";    
+  // this is a temporary function until the grayscaleColors method is merged
+  // into the released version of VictoryUtil
+  getColor(name) {
+    return Util.style.grayscaleColors ? Util.style.grayscaleColors(name) :
+      "#9f9f9f";    
   }
 
   containsStrings(collection) {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -295,9 +295,9 @@ class VBar extends React.Component {
   }
 
   getColor(props, index) {
-    const useColorScale = Array.isArray(props.colorScale) ?
+    const colorScale = Array.isArray(props.colorScale) ?
       props.colorScale : Util.style.getColorScale(props.colorScale);
-    return useColorScale[index % useColorScale.length];
+    return colorScale[index % colorScale.length];
   }
 
   createStringMap(props, axis) {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -278,10 +278,11 @@ class VBar extends React.Component {
   _getAttributes(props, index) {
     let attributes = props.dataAttributes && props.dataAttributes[index] ?
       props.dataAttributes[index] : props.dataAttributes;
-    // see if attributes as fill; if it does not, add fill as randomly
-    // generated. see what's going on here to figure out how to get to fill
-    attributes ? attributes.fill = attributes.fill || this.getColor(index) :
+    if (attributes) {
+      attributes.fill = attributes.fill || this.getColor(index);
+    } else {
       attributes = {fill: this.getColor(index)};
+    }
 
     const requiredAttributes = {
       name: attributes && attributes.name ? attributes.name : "data-" + index
@@ -290,7 +291,7 @@ class VBar extends React.Component {
   }
 
   getColor(index) {
-    return Util.style.getColorScale(this.props.colorScale)[index%5];
+    return Util.style.getColorScale(this.props.colorScale)[index % 5];
   }
 
   createStringMap(props, axis) {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -114,9 +114,14 @@ export default class VictoryBar extends React.Component {
      * baked-in color scales: "victory", "grayscale", "red", "bluePurple", and "yellowBlue".
      * If it is not defined, the default Victory grayscale will be used, and if the fill
      * property on the dataAttributes prop is defined, it will overwrite the colorScale prop.
+     * The user can pass in an array of hex string values to use as their own scale, and
+     * VictoryBar will automatically assign values from this color scale to the bars.
      */
-    colorScale: React.PropTypes.oneOf([
-      "victory", "grayscale", "red", "bluePurple", "yellowBlue"
+    colorScale: React.PropTypes.oneOfType([
+      React.PropTypes.arrayOf(React.PropTypes.string),
+      React.PropTypes.oneOf([
+        "victory", "grayscale", "red", "bluePurple", "yellowBlue"
+      ])
     ]),
     /**
      * The domain prop describes the range of values your bar chart will cover. This prop can be
@@ -279,19 +284,20 @@ class VBar extends React.Component {
     let attributes = props.dataAttributes && props.dataAttributes[index] ?
       props.dataAttributes[index] : props.dataAttributes;
     if (attributes) {
-      attributes.fill = attributes.fill || this.getColor(index);
+      attributes.fill = attributes.fill || this.getColor(props, index);
     } else {
-      attributes = {fill: this.getColor(index)};
+      attributes = {fill: this.getColor(props, index)};
     }
-
     const requiredAttributes = {
       name: attributes && attributes.name ? attributes.name : "data-" + index
     };
     return _.merge(requiredAttributes, attributes);
   }
 
-  getColor(index) {
-    return Util.style.getColorScale(this.props.colorScale)[index % 5];
+  getColor(props, index) {
+    const useColorScale = Array.isArray(props.colorScale) ?
+      props.colorScale : Util.style.getColorScale(props.colorScale);
+    return useColorScale[index % useColorScale.length];
   }
 
   createStringMap(props, axis) {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -294,7 +294,7 @@ class VBar extends React.Component {
   createStringMap(props, axis) {
     // if categories exist and are strings, create a map using only those strings
     // don't alter the order.
-    if (props.categories && this.containsStrings(props.categories)) {
+    if (props.categories && Util.collection.containsStrings(props.categories)) {
       return _.zipObject(_.map(props.categories, (tick, index) => {
         return ["" + tick, index + 1];
       }));
@@ -362,7 +362,7 @@ class VBar extends React.Component {
   }
 
   _getDomainFromCategories(props, axis) {
-    if (axis !== "x" || !props.categories || this.containsStrings(props.categories)) {
+    if (axis !== "x" || !props.categories || Util.collection.containsStrings(props.categories)) {
       return undefined;
     }
     return [_.min(_.flatten(props.categories)), _.max(_.flatten(props.categories))];

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -268,9 +268,10 @@ class VBar extends React.Component {
   _getAttributes(props, index) {
     let attributes = props.dataAttributes && props.dataAttributes[index] ?
       props.dataAttributes[index] : props.dataAttributes;
-    // note: getColor will be replaced by Util.style.grayscaleColors
-    attributes ? attributes.fill = attributes.fill || getColor("bar") :
-      attributes = {fill: this.getColor()};
+    // see if attributes as fill; if it does not, add fill as randomly
+    // generated. see what's going on here to figure out how to get to fill
+    attributes ? attributes.fill = attributes.fill || this.getColor(index) :
+      attributes = {fill: this.getColor(index)};
 
     const requiredAttributes = {
       name: attributes && attributes.name ? attributes.name : "data-" + index
@@ -278,11 +279,8 @@ class VBar extends React.Component {
     return _.merge(requiredAttributes, attributes);
   }
 
-  // this is a temporary function until the grayscaleColors method is merged
-  // into the released version of VictoryUtil
-  getColor(name) {
-    return Util.style.grayscaleColors ? Util.style.grayscaleColors(name) :
-      "#9f9f9f";    
+  getColor(index) {
+    return Util.style.generateColorScale("victory")[index%5];
   }
 
   containsStrings(collection) {
@@ -294,7 +292,7 @@ class VBar extends React.Component {
   createStringMap(props, axis) {
     // if categories exist and are strings, create a map using only those strings
     // don't alter the order.
-    if (props.categories && Util.collection.containsStrings(props.categories)) {
+    if (props.categories && this.containsStrings(props.categories)) {
       return _.zipObject(_.map(props.categories, (tick, index) => {
         return ["" + tick, index + 1];
       }));
@@ -362,7 +360,7 @@ class VBar extends React.Component {
   }
 
   _getDomainFromCategories(props, axis) {
-    if (axis !== "x" || !props.categories || Util.collection.containsStrings(props.categories)) {
+    if (axis !== "x" || !props.categories || this.containsStrings(props.categories)) {
       return undefined;
     }
     return [_.min(_.flatten(props.categories)), _.max(_.flatten(props.categories))];

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -265,12 +265,21 @@ class VBar extends React.Component {
   }
 
   _getAttributes(props, index) {
-    const attributes = props.dataAttributes && props.dataAttributes[index] ?
+    let attributes = props.dataAttributes && props.dataAttributes[index] ?
       props.dataAttributes[index] : props.dataAttributes;
+    // see if attributes as fill; if it does not, add fill as randomly
+    // generated. see what's going on here to figure out how to get to fill
+    attributes ? attributes.fill = attributes.fill || this.getColor() :
+      attributes = {fill: this.getColor()};
+
     const requiredAttributes = {
       name: attributes && attributes.name ? attributes.name : "data-" + index
     };
     return _.merge(requiredAttributes, attributes);
+  }
+
+  getColor() {
+    return "#9f9f9f";    
   }
 
   containsStrings(collection) {


### PR DESCRIPTION
I alphabetized the props in victory-bar.jsx so there are some red-herring changes below, but I:
-- created a colorScale prop
-- used the prop to call VictoryUtil's getColorScale method when no fill was given in dataAttributes
-- removed hard-coded containsStrings method and replaced it with the VictoryUtil method
