### PR TITLE
refactor labels

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -4,6 +4,7 @@ import _ from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
 import {VictoryBar} from "../src/index";
+import {VictoryLabel} from "victory-label";
 
 class App extends React.Component {
   constructor(props) {
@@ -69,6 +70,7 @@ class App extends React.Component {
           <VictoryBar
             height={500}
             data={this.state.numericBarData}
+            labelComponents={[<VictoryLabel>LABELLLL</VictoryLabel>]}
             dataAttributes={[
               {fill: "cornflowerblue"},
               {fill: "orange"},

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -81,13 +81,7 @@ class App extends React.Component {
 
             <VictoryBar
             data={this.state.barData}
-            dataAttributes={[
-              {fill: "cornflowerblue"},
-              {fill: "orange"},
-              {fill: "greenyellow"},
-              {fill: "gold"},
-              {fill: "tomato"}
-            ]}
+            colorScale={"yellowBlue"}
             categoryLabels={["one", "two", "three"]}
             stacked
             animate={{velocity: 0.02}}/>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -4,6 +4,7 @@ import _ from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
 import {VictoryBar} from "../src/index";
+import {VictoryLabel} from "victory-label";
 
 class App extends React.Component {
   constructor(props) {
@@ -80,14 +81,35 @@ class App extends React.Component {
             categories={[[1, 3], [4, 7], [9, 11]]}
             animate={{velocity: 0.02}}/>
 
-            <VictoryBar
+          <VictoryBar
+            width={350}
             data={this.state.barData}
             colorScale={"yellowBlue"}
-            categoryLabels={["one", "two", "three"]}
+            labels={["one", "two", "three"]}
             stacked
             animate={{velocity: 0.02}}/>
 
-            <VictoryBar/>
+          <VictoryBar
+            width={350}
+            data={[
+              {x: 0, y: 1},
+              {x: 1, y: -1},
+              {x: 2, y: 2}
+            ]}
+            dataAttributes={{fill: "tomato"}}
+            labelComponents={[
+              <VictoryLabel textAnchor="middle" verticalAnchor="end">
+                {"TEST"}
+              </VictoryLabel>,
+              <VictoryLabel textAnchor="middle" verticalAnchor="start">
+                {"TEST"}
+              </VictoryLabel>,
+              <VictoryLabel textAnchor="middle" verticalAnchor="end">
+                {"TEST"}
+              </VictoryLabel>
+            ]}/>
+
+          <VictoryBar/>
 
         </p>
       </div>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -81,7 +81,13 @@ class App extends React.Component {
 
             <VictoryBar
             data={this.state.barData}
-            colorScale={"yellowBlue"}
+            dataAttributes={[
+              {fill: "cornflowerblue"},
+              {fill: "orange"},
+              {fill: "greenyellow"},
+              {fill: "gold"},
+              {fill: "tomato"}
+            ]}
             categoryLabels={["one", "two", "three"]}
             stacked
             animate={{velocity: 0.02}}/>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -4,7 +4,6 @@ import _ from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
 import {VictoryBar} from "../src/index";
-import {VictoryLabel} from "victory-label";
 
 class App extends React.Component {
   constructor(props) {
@@ -84,28 +83,9 @@ class App extends React.Component {
             <VictoryBar
             data={this.state.barData}
             colorScale={"yellowBlue"}
-            labels={["one", "two", "three"]}
+            categoryLabels={["one", "two", "three"]}
             stacked
             animate={{velocity: 0.02}}/>
-
-            <VictoryBar
-              data={[
-                {x: 0, y: 1},
-                {x: 1, y: -1},
-                {x: 2, y: 2}
-              ]}
-              dataAttributes={{fill: "tomato"}}
-              labelComponents={[
-                <VictoryLabel textAnchor="middle" verticalAnchor="end">
-                  {"TEST"}
-                </VictoryLabel>,
-                <VictoryLabel textAnchor="middle" verticalAnchor="start">
-                  {"TEST"}
-                </VictoryLabel>,
-                <VictoryLabel textAnchor="middle" verticalAnchor="end">
-                  {"TEST"}
-                </VictoryLabel>
-              ]}/>
 
             <VictoryBar/>
 

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -4,6 +4,7 @@ import _ from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
 import {VictoryBar} from "../src/index";
+import {VictoryLabel} from "victory-label";
 
 class App extends React.Component {
   constructor(props) {
@@ -77,7 +78,6 @@ class App extends React.Component {
             ]}
             horizontal
             categories={[[1, 3], [4, 7], [9, 11]]}
-            labels={["geese", "ducks", "cornish game hens"]}
             animate={{velocity: 0.02}}/>
 
             <VictoryBar
@@ -93,16 +93,20 @@ class App extends React.Component {
                 {x: 1, y: -1},
                 {x: 2, y: 2}
               ]}
-              labels={[
-                "first",
-                "middle",
-                "last"
-              ]}
-              dataAttributes={[
-                {fill: "cornflowerblue"},
-                {fill: "gold"},
-                {fill: "tomato"}
+              dataAttributes={{fill: "tomato"}}
+              labelComponents={[
+                <VictoryLabel textAnchor="middle" verticalAnchor="end">
+                  {"TEST"}
+                </VictoryLabel>,
+                <VictoryLabel textAnchor="middle" verticalAnchor="start">
+                  {"TEST"}
+                </VictoryLabel>,
+                <VictoryLabel textAnchor="middle" verticalAnchor="end">
+                  {"TEST"}
+                </VictoryLabel>
               ]}/>
+
+            <VictoryBar/>
 
         </p>
       </div>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -4,7 +4,6 @@ import _ from "lodash";
 import React from "react";
 import ReactDOM from "react-dom";
 import {VictoryBar} from "../src/index";
-import {VictoryLabel} from "victory-label";
 
 class App extends React.Component {
   constructor(props) {
@@ -81,35 +80,14 @@ class App extends React.Component {
             categories={[[1, 3], [4, 7], [9, 11]]}
             animate={{velocity: 0.02}}/>
 
-          <VictoryBar
-            width={350}
+            <VictoryBar
             data={this.state.barData}
             colorScale={"yellowBlue"}
             labels={["one", "two", "three"]}
             stacked
             animate={{velocity: 0.02}}/>
 
-          <VictoryBar
-            width={350}
-            data={[
-              {x: 0, y: 1},
-              {x: 1, y: -1},
-              {x: 2, y: 2}
-            ]}
-            dataAttributes={{fill: "tomato"}}
-            labelComponents={[
-              <VictoryLabel textAnchor="middle" verticalAnchor="end">
-                {"TEST"}
-              </VictoryLabel>,
-              <VictoryLabel textAnchor="middle" verticalAnchor="start">
-                {"TEST"}
-              </VictoryLabel>,
-              <VictoryLabel textAnchor="middle" verticalAnchor="end">
-                {"TEST"}
-              </VictoryLabel>
-            ]}/>
-
-          <VictoryBar/>
+            <VictoryBar/>
 
         </p>
       </div>

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -83,7 +83,7 @@ class App extends React.Component {
             <VictoryBar
             data={this.state.barData}
             colorScale={"yellowBlue"}
-            categoryLabels={["one", "two", "three"]}
+            labels={["one", "two", "three"]}
             stacked
             animate={{velocity: 0.02}}/>
 

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -77,16 +77,32 @@ class App extends React.Component {
             ]}
             horizontal
             categories={[[1, 3], [4, 7], [9, 11]]}
+            labels={["geese", "ducks", "cornish game hens"]}
             animate={{velocity: 0.02}}/>
 
             <VictoryBar
             data={this.state.barData}
             colorScale={"yellowBlue"}
-            categoryLabels={["one", "two", "three"]}
+            labels={["one", "two", "three"]}
             stacked
             animate={{velocity: 0.02}}/>
 
-            <VictoryBar/>
+            <VictoryBar
+              data={[
+                {x: 0, y: 1},
+                {x: 1, y: -1},
+                {x: 2, y: 2}
+              ]}
+              labels={[
+                "first",
+                "middle",
+                "last"
+              ]}
+              dataAttributes={[
+                {fill: "cornflowerblue"},
+                {fill: "gold"},
+                {fill: "tomato"}
+              ]}/>
 
         </p>
       </div>

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "url-loader": "~0.5.5",
     "victory-animation": "^0.0.10",
     "victory-util": "git+https://github.com/formidablelabs/victory-util#master",
+    "victory-label": "git+https://github.com/FormidableLabs/victory-label#master",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -3,7 +3,7 @@ import Radium from "radium";
 import _ from "lodash";
 import d3 from "d3";
 import {VictoryAnimation} from "victory-animation";
-import {Util} from "victory-util";
+import Util from "victory-util";
 import {VictoryLabel} from "victory-label";
 
 const styles = {
@@ -541,11 +541,36 @@ export default class VictoryBar extends React.Component {
     };
   }
 
-  getLabelPositions(props, position) {
-    return {
-      xPosition: props.horizontal ? position.dependent1 : position.independent,
-      yPosition: props.horizontal ? position.independent : position.dependent1
-    };
+  getLabel(position, sign, label) {
+    let verticalAnchor;
+    let horizontalAnchor;
+    let xPosition = this.props.horizontal ? position.dependent1 : position.independent;
+    const yPosition = this.props.horizontal ? position.independent : position.dependent1;
+
+    if (!this.props.horizontal) {
+      verticalAnchor = sign >= 0 ? "end" : "start";
+      horizontalAnchor = "middle";
+    } else {
+      verticalAnchor = "middle";
+      if (sign >= 0) {
+        horizontalAnchor = "start";
+        xPosition += 2;
+      } else {
+        horizontalAnchor = "end";
+        xPosition -= 2;
+      }
+    }
+
+    return (
+      <VictoryLabel
+        x={xPosition}
+        y={yPosition}
+        textAnchor={horizontalAnchor}
+        verticalAnchor={verticalAnchor}
+        style={this.style.labels}>
+        {label}
+      </VictoryLabel>
+    );
   }
 
   getBarElements(dataset, index) {
@@ -561,16 +586,15 @@ export default class VictoryBar extends React.Component {
         "xName", "yName", "x", "y", "label"
         ]);
       const style = _.merge({}, this.style.data, _.omit(dataset.attrs, "name"), styleData);
-      const {xPosition, yPosition} = this.getLabelPositions(this.props, position);
+      const sign = data.y >= 0 ? 1 : -1;
+
       if (this.props.categoryLabels && plotCategoryLabel) {
         categoryLabel = this.selectCategotyLabel(data.x);
       }
+
       const label = stacked ? categoryLabel : (data.label || categoryLabel);
 
       if (label) {
-        // the verticalAnchor will need to change based on positive/negative bars
-        // and textAnchor will need to change when horizontal, and same with positive/negative bars
-        const sign = data.y >= 0 ? 1 : -1;
         return (
           <g key={"series-" + index + "-bar-" + barIndex}>
             <path
@@ -578,14 +602,7 @@ export default class VictoryBar extends React.Component {
               shapeRendering="optimizeSpeed"
               style={style}>
             </path>
-            <VictoryLabel
-              x={xPosition}
-              y={yPosition}
-              textAnchor="middle"
-              verticalAnchor="end"
-              style={this.style.labels}>
-              {label}
-            </VictoryLabel>
+            {this.getLabel(position, sign, label)}
           </g>
         );
       }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -504,7 +504,7 @@ export default class VictoryBar extends React.Component {
     });
   }
 
-  selectCategoryLabel(x) {
+  selectLabel(x) {
     let index;
     if (this.stringMap.x) {
       return this.props.labels[x - 1];
@@ -537,7 +537,7 @@ export default class VictoryBar extends React.Component {
     };
   }
 
-  getLabel(position, sign, label) {
+  _renderVictoryLabel(position, sign, labelText) {
     let verticalAnchor;
     let horizontalAnchor;
     let xPosition = this.props.horizontal ? position.dependent1 : position.independent;
@@ -564,7 +564,7 @@ export default class VictoryBar extends React.Component {
         textAnchor={horizontalAnchor}
         verticalAnchor={verticalAnchor}
         style={this.style.labels}>
-        {label}
+        {labelText}
       </VictoryLabel>
     );
   }
@@ -575,7 +575,7 @@ export default class VictoryBar extends React.Component {
     const stacked = this.props.stacked;
     const plotCategoryLabel = (stacked && isLast) || (!stacked && isCenter);
     return _.map(dataset.data, (data, barIndex) => {
-      let categoryLabel;
+      let label;
       const position = this.getBarPosition(data, index, barIndex);
       const path = position.independent ? this.getBarPath(position) : undefined;
       const styleData = _.omit(data, [
@@ -585,12 +585,10 @@ export default class VictoryBar extends React.Component {
       const sign = data.y >= 0 ? 1 : -1;
 
       if (this.props.labels && plotCategoryLabel) {
-        categoryLabel = this.selectCategoryLabel(data.x);
+        label = this.selectLabel(data.x);
       }
 
-      // const label = stacked ? categoryLabel : (data.label || categoryLabel);
-
-      if (categoryLabel) {
+      if (label) {
         return (
           <g key={"series-" + index + "-bar-" + barIndex}>
             <path
@@ -598,7 +596,7 @@ export default class VictoryBar extends React.Component {
               shapeRendering="optimizeSpeed"
               style={style}>
             </path>
-            {this.getLabel(position, sign, categoryLabel)}
+            {this._renderVictoryLabel(position, sign, label)}
           </g>
         );
       }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -19,9 +19,6 @@ const styles = {
     strokeWidth: 0,
     fill: "#756f6a",
     opacity: 1
-  },
-  labels: {
-    fontSize: 12
   }
 };
 
@@ -94,16 +91,15 @@ export default class VictoryBar extends React.Component {
      */
     categories: React.PropTypes.array,
     /**
-     * The categoryLabels prop defines labels that will appear above each bar or
-     * group of bars in your bar chart This prop should be given as an array of values.
+     * The labels prop defines labels that will appear above each bar or
+     * group of bars in your bar chart. This prop should be given as an array of values.
      * The number of elements in the label array should be equal to number of elements in
      * the categories array, or if categories is not defined, to the number of unique
-     * x values in your data. Use this prop to add labels to stacked bars and groups of
-     * bars. Adding labels to individual bars can be accomplished by adding a label
-     * property directly to the data object.
+     * x values in your data. Use this prop to add labels to individual bars, stacked bars,
+     * and groups of bars.
      * @examples: ["spring", "summer", "fall", "winter"]
      */
-    categoryLabels: React.PropTypes.array,
+    labels: React.PropTypes.array,
     /**
      * The colorScale prop is an optional prop that defines the color scale the chart's bars
      * will be created on. This prop should be given as a string, which will one of the five
@@ -116,7 +112,11 @@ export default class VictoryBar extends React.Component {
     colorScale: React.PropTypes.oneOfType([
       React.PropTypes.arrayOf(React.PropTypes.string),
       React.PropTypes.oneOf([
-        "victory", "gray", "red", "bluePurple", "yellowBlue"
+        "victory",
+        "gray",
+        "red",
+        "bluePurple",
+        "yellowBlue"
       ])
     ]),
     /**
@@ -274,7 +274,7 @@ export default class VictoryBar extends React.Component {
   }
 
   getColor(props, index) {
-    const colorScale = Array.isArray(props.colorScale) ?
+    const colorScale = _.isArray(props.colorScale) ?
       props.colorScale : Util.style.getColorScale(props.colorScale);
     return colorScale[index % colorScale.length];
   }
@@ -504,23 +504,23 @@ export default class VictoryBar extends React.Component {
     });
   }
 
-  selectCategotyLabel(x) {
+  selectCategoryLabel(x) {
     let index;
     if (this.stringMap.x) {
-      return this.props.categoryLabels[x - 1];
+      return this.props.labels[x - 1];
     } else if (this.props.categories) {
       index = _.findIndex(this.props.categories, (category) => {
         return _.isArray(category) ? (_.min(category) <= x && _.max(category) >= x) :
           category === x;
       });
-      return this.props.categoryLabels[index];
+      return this.props.labels[index];
     } else {
       const allX = _.map(this.datasets, (dataset) => {
         return _.map(dataset.data, "x");
       });
       const uniqueX = _.uniq(_.flatten(allX));
       index = (_.findIndex(_.sortBy(uniqueX), (n) => n === x));
-      return this.props.categoryLabels[index];
+      return this.props.labels[index];
     }
   }
 
@@ -584,13 +584,13 @@ export default class VictoryBar extends React.Component {
       const style = _.merge({}, this.style.data, _.omit(dataset.attrs, "name"), styleData);
       const sign = data.y >= 0 ? 1 : -1;
 
-      if (this.props.categoryLabels && plotCategoryLabel) {
-        categoryLabel = this.selectCategotyLabel(data.x);
+      if (this.props.labels && plotCategoryLabel) {
+        categoryLabel = this.selectCategoryLabel(data.x);
       }
 
-      const label = stacked ? categoryLabel : (data.label || categoryLabel);
+      // const label = stacked ? categoryLabel : (data.label || categoryLabel);
 
-      if (label) {
+      if (categoryLabel) {
         return (
           <g key={"series-" + index + "-bar-" + barIndex}>
             <path
@@ -598,7 +598,7 @@ export default class VictoryBar extends React.Component {
               shapeRendering="optimizeSpeed"
               style={style}>
             </path>
-            {this.getLabel(position, sign, label)}
+            {this.getLabel(position, sign, categoryLabel)}
           </g>
         );
       }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -23,10 +23,9 @@ const styles = {
   labels: {
     padding: 5,
     fontFamily: "Helvetica", //TODO fontstack? (can React styles do that?)
-    fontSize: 14,
+    fontSize: 12,
     strokeWidth: 0,
-    stroke: "transparent",
-    textAnchor: "middle"
+    stroke: "transparent"
   }
 };
 
@@ -583,6 +582,8 @@ class VBar extends React.Component {
       const label = stacked ? categoryLabel : (data.label || categoryLabel);
 
       if (label) {
+        // the verticalAnchor will need to change based on positive/negative bars
+        // and textAnchor will need to change when horizontal, and same with positive/negative bars
         const sign = data.y >= 0 ? 1 : -1;
         return (
           <g key={"series-" + index + "-bar-" + barIndex}>
@@ -591,12 +592,14 @@ class VBar extends React.Component {
               shapeRendering="optimizeSpeed"
               style={style}>
             </path>
-            <text
+            <VictoryLabel
               x={xPosition}
               y={yPosition}
+              textAnchor="middle"
+              verticalAnchor="end"
               style={this.style.labels}>
-              {this.getTextLines(label, position, sign)}
-            </text>
+              {label}
+            </VictoryLabel>
           </g>
         );
       }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -21,11 +21,7 @@ const styles = {
     opacity: 1
   },
   labels: {
-    padding: 5,
-    fontFamily: "Helvetica", //TODO fontstack? (can React styles do that?)
-    fontSize: 12,
-    strokeWidth: 0,
-    stroke: "transparent"
+    fontSize: 12
   }
 };
 

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -3,7 +3,8 @@ import Radium from "radium";
 import _ from "lodash";
 import d3 from "d3";
 import {VictoryAnimation} from "victory-animation";
-import Util from "victory-util";
+import {Util} from "victory-util";
+import {VictoryLabel} from "victory-label";
 
 const defaultStyles = {
   data: {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -18,10 +18,9 @@ const defaultStyles = {
   labels: {
     padding: 5,
     fontFamily: "Helvetica", //TODO fontstack? (can React styles do that?)
-    fontSize: 14,
+    fontSize: 12,
     strokeWidth: 0,
-    stroke: "transparent",
-    textAnchor: "middle"
+    stroke: "transparent"
   }
 };
 
@@ -576,6 +575,8 @@ export default class VictoryBar extends React.Component {
       const label = stacked ? categoryLabel : (data.label || categoryLabel);
 
       if (label) {
+        // the verticalAnchor will need to change based on positive/negative bars
+        // and textAnchor will need to change when horizontal, and same with positive/negative bars
         const sign = data.y >= 0 ? 1 : -1;
         return (
           <g key={"series-" + index + "-bar-" + barIndex}>
@@ -584,12 +585,14 @@ export default class VictoryBar extends React.Component {
               shapeRendering="optimizeSpeed"
               style={style}>
             </path>
-            <text
+            <VictoryLabel
               x={xPosition}
               y={yPosition}
+              textAnchor="middle"
+              verticalAnchor="end"
               style={this.style.labels}>
-              {this.getTextLines(label, position, sign)}
-            </text>
+              {label}
+            </VictoryLabel>
           </g>
         );
       }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -630,6 +630,9 @@ _renderVictoryLabel(position, sign, label) {
       }
 
       if (label) {
+        // the verticalAnchor will need to change based on positive/negative bars
+        // and textAnchor will need to change when horizontal, and same with positive/negative bars
+        const sign = data.y >= 0 ? 1 : -1;
         return (
           <g key={"series-" + index + "-bar-" + barIndex}>
             <path

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -23,10 +23,9 @@ const styles = {
   labels: {
     padding: 5,
     fontFamily: "Helvetica", //TODO fontstack? (can React styles do that?)
-    fontSize: 14,
+    fontSize: 12,
     strokeWidth: 0,
-    stroke: "transparent",
-    textAnchor: "middle"
+    stroke: "transparent"
   }
 };
 
@@ -569,6 +568,8 @@ export default class VictoryBar extends React.Component {
       const label = stacked ? categoryLabel : (data.label || categoryLabel);
 
       if (label) {
+        // the verticalAnchor will need to change based on positive/negative bars
+        // and textAnchor will need to change when horizontal, and same with positive/negative bars
         const sign = data.y >= 0 ? 1 : -1;
         return (
           <g key={"series-" + index + "-bar-" + barIndex}>
@@ -577,12 +578,14 @@ export default class VictoryBar extends React.Component {
               shapeRendering="optimizeSpeed"
               style={style}>
             </path>
-            <text
+            <VictoryLabel
               x={xPosition}
               y={yPosition}
+              textAnchor="middle"
+              verticalAnchor="end"
               style={this.style.labels}>
-              {this.getTextLines(label, position, sign)}
-            </text>
+              {label}
+            </VictoryLabel>
           </g>
         );
       }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -532,7 +532,7 @@ export default class VictoryBar extends React.Component {
     const labels = this.props.labelComponents ? this.props.labelComponents : this.props.labels;
 
     if (this.stringMap.x) {
-      return labels[x - 1];
+      return labels[(x - 1) % labels.length];
     } else if (this.props.categories) {
       index = _.findIndex(this.props.categories, (category) => {
         return _.isArray(category) ? (_.min(category) <= x && _.max(category) >= x) :
@@ -545,7 +545,7 @@ export default class VictoryBar extends React.Component {
       });
       const uniqueX = _.uniq(_.flatten(allX));
       index = (_.findIndex(_.sortBy(uniqueX), (n) => n === x));
-      return labels[index];
+      return labels[index % labels.length];
     }
   }
 
@@ -592,22 +592,24 @@ _renderVictoryLabel(position, sign, label) {
     );
   }
 
-  _renderGivenLabel(position, label) {
+  _renderGivenLabel(position, label, index) {
+    debugger;
     const parentLabelStyles = (this.props.style && this.props.style.labels) ?
       this.props.style.labels : {};
     const style = _.merge({}, parentLabelStyles, label.props.style);
     const xPosition = this.props.horizontal ? position.dependent1 : position.independent;
     const yPosition = this.props.horizontal ? position.independent : position.dependent1;
+    const text = label.props.children || (this.props.labels[index % this.props.labels.length] || "");
 
     return React.cloneElement(label, {
       x: xPosition,
       y: yPosition
-    });
+    }, text);
   }
 
-  _renderLabel(position, sign, label) {
+  _renderLabel(position, sign, label, index) {
     return _.isString(label) ? this._renderVictoryLabel(position, sign, label) :
-      this._renderGivenLabel(position, label);
+      this._renderGivenLabel(position, label, index);
   }
 
   getBarElements(dataset, index) {
@@ -640,7 +642,7 @@ _renderVictoryLabel(position, sign, label) {
               shapeRendering="optimizeSpeed"
               style={style}>
             </path>
-            {this._renderLabel(position, sign, label)}
+            {this._renderLabel(position, sign, label, index)}
           </g>
         );
       }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -3,7 +3,8 @@ import Radium from "radium";
 import _ from "lodash";
 import d3 from "d3";
 import {VictoryAnimation} from "victory-animation";
-import Util from "victory-util";
+import {Util} from "victory-util";
+import {VictoryLabel} from "victory-label";
 
 const styles = {
   parent: {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -529,7 +529,7 @@ export default class VictoryBar extends React.Component {
 
   selectLabel(x, isText) {
     let index;
-    const labels = isText? this.props.labels : this.props.labelComponents || this.props.labels;
+    const labels = isText ? this.props.labels : this.props.labelComponents || this.props.labels;
 
     if (this.stringMap.x) {
       return labels[(x - 1) % labels.length];
@@ -571,7 +571,6 @@ _renderVictoryLabel(position, sign, label) {
       horizontalAnchor = "middle";
     } else {
       verticalAnchor = "middle";
-      position.x - sign * 2
       horizontalAnchor = sign >= 0 ? "start" : "end";
     }
     return (
@@ -594,13 +593,14 @@ _renderVictoryLabel(position, sign, label) {
 
     return React.cloneElement(label, {
       x: position.x,
-      y: position.y
+      y: position.y,
+      style
     }, text);
   }
 
   _renderLabel(position, data, label) {
     const sign = data.y >= 0 ? 1 : -1;
-    let adjustedPositions = {
+    const adjustedPositions = {
       x: this.props.horizontal ? position.dependent1 : position.independent,
       y: this.props.horizontal ? position.independent : position.dependent1
     };

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -571,13 +571,10 @@ export default class VictoryBar extends React.Component {
     }
   }
 
-  renderLabel(labelData) {
+  renderLabel(labelData, labelText) {
     const {labelPositions, data, index} = labelData;
     const labelComponent = this.props.labelComponents ?
-      this.props.labelComponents[index] || this.props.labelComponents[0] :
-      undefined;
-    const labelText = this.props.labels ?
-      this.props.labels[index] || this.props.labels[0] : data.y;
+      this.props.labelComponents[index] || this.props.labelComponents[0] : undefined;
     const sign = data.y >= 0 ? 1 : -1;
     const anchors = this._getAnchors(sign);
     const componentStyle = labelComponent && labelComponent.props.style;
@@ -586,11 +583,11 @@ export default class VictoryBar extends React.Component {
 
     const props = {
       key: "label-" + index,
-      x: labelPositions.x,
-      y: labelPositions.y,
+      x: (labelComponent && labelComponent.props.x) || labelPositions.x,
+      y: (labelComponent && labelComponent.props.y) || labelPositions.y,
       data, // Pass data for custom label component to access
-      textAnchor: anchors.text,
-      verticalAnchor: anchors.vertical,
+      textAnchor: (labelComponent && labelComponent.props.textAnchor) || anchors.text,
+      verticalAnchor: (labelComponent && labelComponent.props.textAnchor) || anchors.vertical,
       style
     };
 
@@ -618,7 +615,10 @@ export default class VictoryBar extends React.Component {
           x: this.props.horizontal ? position.dependent1 : position.independent,
           y: this.props.horizontal ? position.independent : position.dependent1
         };
-        const labelData = {labelPositions, data, index: this.getLabelIndex(data.x)};
+        const labelIndex = this.getLabelIndex(data.x);
+        const labelData = {labelPositions, data, index: labelIndex};
+        const labelText = this.props.labels ?
+          this.props.labels[labelIndex] || this.props.labels[0] : "";
         return (
           <g key={"series-" + index + "-bar-" + barIndex}>
             <path
@@ -626,7 +626,7 @@ export default class VictoryBar extends React.Component {
               shapeRendering="optimizeSpeed"
               style={style}>
             </path>
-            {this.renderLabel(labelData)}
+            {this.renderLabel(labelData, labelText)}
           </g>
         );
       }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -16,11 +16,7 @@ const defaultStyles = {
     opacity: 1
   },
   labels: {
-    padding: 5,
-    fontFamily: "Helvetica", //TODO fontstack? (can React styles do that?)
-    fontSize: 12,
-    strokeWidth: 0,
-    stroke: "transparent"
+    fontSize: 12
   }
 };
 

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -492,41 +492,6 @@ export default class VictoryBar extends React.Component {
     }, 0);
   }
 
-  getTextLines(text, position, sign) {
-    if (!text) {
-      return "";
-    }
-    // TODO: split text to new lines based on font size, number of characters and total width
-    const textString = "" + text;
-    const textLines = textString.split("\n");
-    const maxLength = _.max(textLines, line => { return line.length; }).length;
-    return _.map(textLines, (line, index) => {
-      const fontSize = this.style.labels.fontSize;
-      const order = sign === 1 ? (textLines.length - index) : (index + 1);
-      const offset = order * sign * -(fontSize);
-      if (this.props.horizontal) {
-        const offsetY = sign < 0 ?
-          order * fontSize - fontSize * textLines.length / 1.6 :
-          order * (-1) * fontSize +
-            fontSize * textLines.length / 1;
-        const offsetX = sign * (fontSize) / 3 * maxLength;
-        return (
-          <tspan x={position.dependent1} y={position.independent}
-            dx={offsetX} dy={offsetY} key={"text-line-" + index}>
-            {line}
-          </tspan>
-        );
-      } else {
-        return (
-          <tspan x={position.independent} y={position.dependent1}
-            dy={offset} key={"text-line-" + index}>
-            {line}
-          </tspan>
-        );
-      }
-    });
-  }
-
   getLabelIndex(x) {
     if (this.stringMap.x) {
       return (x - 1);

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -575,30 +575,16 @@ export default class VictoryBar extends React.Component {
     );
   }
 
-    /*
-    // the old ones were bad
-    getNewChildren() {
-      return _.map(this.childComponents, (child, index) => {
-        const style = _.merge({}, {parent: this.style.parent}, child.props.style);
-        const newProps = this.getNewProps(child);
-        return React.cloneElement(child, _.merge({}, newProps, {
-          ref: index,
-          key: index,
-          standalone: false,
-          style
-        }));
-      });
-    }
-    */
   _renderGivenLabel(position, label) {
-    const style = _.merge({}, this.props.style.labels, label.props.style);
+    const parentLabelStyles = (this.props.style && this.props.style.labels) ?
+      this.props.style.labels : {};
+    const style = _.merge({}, parentLabelStyles, label.props.style);
     const xPosition = this.props.horizontal ? position.dependent1 : position.independent;
     const yPosition = this.props.horizontal ? position.independent : position.dependent1;
 
     return React.cloneElement(label, {
       x: xPosition,
-      y: yPosition,
-      style
+      y: yPosition
     });
   }
 
@@ -622,7 +608,7 @@ export default class VictoryBar extends React.Component {
       const style = _.merge({}, this.style.data, _.omit(dataset.attrs, "name"), styleData);
       const sign = data.y >= 0 ? 1 : -1;
 
-      if (this.props.labels && plotCategoryLabel) {
+      if ((this.props.labels || this.props.labelComponents) && plotCategoryLabel) {
         label = this.selectLabel(data.x);
       }
 

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -527,9 +527,9 @@ export default class VictoryBar extends React.Component {
     });
   }
 
-  selectLabel(x) {
+  selectLabel(x, isText) {
     let index;
-    const labels = this.props.labelComponents ? this.props.labelComponents : this.props.labels;
+    const labels = isText? this.props.labels : this.props.labelComponents || this.props.labels;
 
     if (this.stringMap.x) {
       return labels[(x - 1) % labels.length];
@@ -593,13 +593,12 @@ _renderVictoryLabel(position, sign, label) {
   }
 
   _renderGivenLabel(position, label, index) {
-    debugger;
     const parentLabelStyles = (this.props.style && this.props.style.labels) ?
       this.props.style.labels : {};
     const style = _.merge({}, parentLabelStyles, label.props.style);
     const xPosition = this.props.horizontal ? position.dependent1 : position.independent;
     const yPosition = this.props.horizontal ? position.independent : position.dependent1;
-    const text = label.props.children || (this.props.labels[index % this.props.labels.length] || "");
+    const text = label.props.children || selectLabel(index, true);
 
     return React.cloneElement(label, {
       x: xPosition,
@@ -608,6 +607,7 @@ _renderVictoryLabel(position, sign, label) {
   }
 
   _renderLabel(position, sign, label, index) {
+
     return _.isString(label) ? this._renderVictoryLabel(position, sign, label) :
       this._renderGivenLabel(position, label, index);
   }

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -588,7 +588,7 @@ _renderVictoryLabel(position, sign, label) {
   _renderGivenLabel(position, label, x) {
     const parentLabelStyles = (this.props.style && this.props.style.labels) ?
       this.props.style.labels : {};
-    const style = _.merge({}, parentLabelStyles, label.props.style);
+    const style = _.merge({}, defaultStyles.labels, parentLabelStyles);
     const text = label.props.children || this.selectLabel(x, true);
 
     return React.cloneElement(label, {
@@ -612,7 +612,7 @@ _renderVictoryLabel(position, sign, label) {
     const isCenter = Math.floor(this.datasets.length / 2) === index;
     const isLast = this.datasets.length === index + 1;
     const stacked = this.props.stacked;
-    const plotCategoryLabel = (stacked && isLast) || (!stacked && isCenter);
+    const plotGroupLabel = (stacked && isLast) || (!stacked && isCenter);
     return _.map(dataset.data, (data, barIndex) => {
       let label;
       const position = this.getBarPosition(data, index, barIndex);
@@ -622,7 +622,7 @@ _renderVictoryLabel(position, sign, label) {
         ]);
       const style = _.merge({}, this.style.data, _.omit(dataset.attrs, "name"), styleData);
 
-      if ((this.props.labels || this.props.labelComponents) && plotCategoryLabel) {
+      if ((this.props.labels || this.props.labelComponents) && plotGroupLabel) {
         label = this.selectLabel(data.x);
       }
 


### PR DESCRIPTION
The `categoryLabels` props is renamed to `labels`

VictoryLabels are used unless the user passes one or more label components via the `labelComponents` prop
