### PR TITLE
Fix cumulative max

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "victory-animation": "^0.0.10",
-    "victory-util": "1.1.1",
+    "victory-util": "git+https://github.com/formidablelabs/victory-util#cumulativeMaxMin",
     "victory-label": "0.1.1",
     "webpack": "^1.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "victory-animation": "^0.0.10",
-    "victory-util": "git+https://github.com/formidablelabs/victory-util#master",
+    "victory-util": "git+https://github.com/formidablelabs/victory-util#cumulativeMaxMin",
     "victory-label": "0.1.0",
     "webpack": "^1.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -111,3 +111,4 @@
     "webpack-stats-plugin": "^0.1.1"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "victory-animation": "^0.0.10",
-    "victory-util": "git+https://github.com/formidablelabs/victory-util#master",
     "victory-label": "0.1.1",
+    "victory-util": "git+https://github.com/formidablelabs/victory-util#cumulativeMaxMin",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "style-loader": "~0.8.0",
     "url-loader": "~0.5.5",
     "victory-animation": "^0.0.10",
-    "victory-util": "git+https://github.com/formidablelabs/victory-util#cumulativeMaxMin",
     "victory-label": "0.1.1",
+    "victory-util": "git+https://github.com/formidablelabs/victory-util#cumulativeMaxMin",
     "webpack": "^1.10.0"
   },
   "devDependencies": {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -397,7 +397,11 @@ export default class VictoryBar extends React.Component {
     const organizedArray = [];
     _.forEach(allData, datum => {
       const category = this.determineCategory(datum.x, props) || datum.x;
-      organizedData[category] ? organizedData[category].push(datum) : organizedData[category] = [datum];
+      if (organizedData[category]) {
+        organizedData[category].push(datum);
+      } else {
+        organizedData[category] = [datum];
+      }
     });
     _.forEach(organizedData, category => {
       organizedArray.push(category);

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -385,38 +385,12 @@ export default class VictoryBar extends React.Component {
       // this is only sensible for the y domain
       // TODO check assumption
       const cumulativeMax = (props.stacked && axis === "y" && this.datasets.length > 1) ?
-        this.getCumulativeMax(this.datasets, "y") : -Infinity;
+        Util.collection.getCumulativeMax(this.datasets, "y") : -Infinity;
       const cumulativeMin = (props.stacked && axis === "y" && this.datasets.length > 1) ?
-        this.getCumulativeMin(this.datasets, "y") : Infinity;
+        Util.collection.getCumulativeMin(this.datasets, "y") : Infinity;
       return [_.min([min, cumulativeMin]), _.max([max, cumulativeMax])];
     }
   }
-
-  getCumulativeMax(datasets, dependentAxis) {
-    return _.reduce(datasets, (memo, dataset) => {
-      debugger;
-      dataset = dataset.data || dataset;
-      const localMax = (_.max(_.pluck(dataset, dependentAxis)));
-      return localMax > 0 ? memo + localMax : memo;
-    });
-  }
-
-  getCumulativeMin(datasets, dependentAxis) {
-    return _.reduce(this.datasets, (memo, dataset) => {
-      dataset = dataset.data || dataset;
-      const localMin = (_.min(_.pluck(dataset, dependentAxis)));
-      return localMin < 0 ? memo + localMin : memo;
-    })
-  }
-
-  /*const cumulativeMax = _.reduce(formattedData, (memo, dataset) => {
-    const localMax = (_.max(_.pluck(dataset, this.dependentAxis)));
-    return localMax > 0 ? memo + localMax : memo;
-  }, 0);
-  const cumulativeMin = _.reduce(formattedData, (memo, dataset) => {
-    const localMin = (_.min(_.pluck(dataset, this.dependentAxis)));
-    return localMin < 0 ? memo + localMin : memo;
-  }, 0); */
 
   getBarWidth() {
     // todo calculate / enforce max width

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -392,6 +392,8 @@ export default class VictoryBar extends React.Component {
     }
   }
 
+  // organize datasets into arrays of objects
+  // each array is a category or a stacked bar
   organizeData(allData, props) {
     const organizedData = {};
     const organizedArray = [];

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -386,38 +386,12 @@ export default class VictoryBar extends React.Component {
       // this is only sensible for the y domain
       // TODO check assumption
       const cumulativeMax = (props.stacked && axis === "y" && this.datasets.length > 1) ?
-        this.getCumulativeMax(this.datasets, "y") : -Infinity;
+        Util.collection.getCumulativeMax(this.datasets, "y") : -Infinity;
       const cumulativeMin = (props.stacked && axis === "y" && this.datasets.length > 1) ?
-        this.getCumulativeMin(this.datasets, "y") : Infinity;
+        Util.collection.getCumulativeMin(this.datasets, "y") : Infinity;
       return [_.min([min, cumulativeMin]), _.max([max, cumulativeMax])];
     }
   }
-
-  getCumulativeMax(datasets, dependentAxis) {
-    return _.reduce(datasets, (memo, dataset) => {
-      debugger;
-      dataset = dataset.data || dataset;
-      const localMax = (_.max(_.pluck(dataset, dependentAxis)));
-      return localMax > 0 ? memo + localMax : memo;
-    });
-  }
-
-  getCumulativeMin(datasets, dependentAxis) {
-    return _.reduce(this.datasets, (memo, dataset) => {
-      dataset = dataset.data || dataset;
-      const localMin = (_.min(_.pluck(dataset, dependentAxis)));
-      return localMin < 0 ? memo + localMin : memo;
-    })
-  }
-
-  /*const cumulativeMax = _.reduce(formattedData, (memo, dataset) => {
-    const localMax = (_.max(_.pluck(dataset, this.dependentAxis)));
-    return localMax > 0 ? memo + localMax : memo;
-  }, 0);
-  const cumulativeMin = _.reduce(formattedData, (memo, dataset) => {
-    const localMin = (_.min(_.pluck(dataset, this.dependentAxis)));
-    return localMin < 0 ? memo + localMin : memo;
-  }, 0); */
 
   getBarWidth() {
     // todo calculate / enforce max width

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -382,15 +382,27 @@ export default class VictoryBar extends React.Component {
       const allData = _.flatten(_.pluck(this.datasets, "data"));
       const min = _.min(_.pluck(allData, axis));
       const max = _.max(_.pluck(allData, axis));
-      // find the cumulative max for stacked chart types
-      // this is only sensible for the y domain
-      // TODO check assumption
+      const organizedData = this.organizeData(allData, props);
+      // find the largest height of all of the bars
       const cumulativeMax = (props.stacked && axis === "y" && this.datasets.length > 1) ?
-        Util.collection.getCumulativeMax(this.datasets, "y") : -Infinity;
+        Util.collection.getCumulativeMax(organizedData, "y") : -Infinity;
       const cumulativeMin = (props.stacked && axis === "y" && this.datasets.length > 1) ?
         Util.collection.getCumulativeMin(this.datasets, "y") : Infinity;
       return [_.min([min, cumulativeMin]), _.max([max, cumulativeMax])];
     }
+  }
+
+  organizeData(allData, props) {
+    const organizedData = {};
+    const organizedArray = [];
+    _.forEach(allData, datum => {
+      const category = this.determineCategory(datum.x, props) || datum.x;
+      organizedData[category] ? organizedData[category].push(datum) : organizedData[category] = [datum];
+    });
+    _.forEach(organizedData, category => {
+      organizedArray.push(category);
+    });
+    return organizedArray;
   }
 
   getBarWidth() {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -385,18 +385,38 @@ export default class VictoryBar extends React.Component {
       // this is only sensible for the y domain
       // TODO check assumption
       const cumulativeMax = (props.stacked && axis === "y" && this.datasets.length > 1) ?
-        _.reduce(this.datasets, (memo, dataset) => {
-          const localMax = (_.max(_.pluck(dataset.data, "y")));
-          return localMax > 0 ? memo + localMax : memo;
-        }, 0) : -Infinity;
+        this.getCumulativeMax(this.datasets, "y") : -Infinity;
       const cumulativeMin = (props.stacked && axis === "y" && this.datasets.length > 1) ?
-        _.reduce(this.datasets, (memo, dataset) => {
-          const localMin = (_.min(_.pluck(dataset.data, "y")));
-          return localMin < 0 ? memo + localMin : memo;
-        }, 0) : Infinity;
+        this.getCumulativeMin(this.datasets, "y") : Infinity;
       return [_.min([min, cumulativeMin]), _.max([max, cumulativeMax])];
     }
   }
+
+  getCumulativeMax(datasets, dependentAxis) {
+    return _.reduce(datasets, (memo, dataset) => {
+      debugger;
+      dataset = dataset.data || dataset;
+      const localMax = (_.max(_.pluck(dataset, dependentAxis)));
+      return localMax > 0 ? memo + localMax : memo;
+    });
+  }
+
+  getCumulativeMin(datasets, dependentAxis) {
+    return _.reduce(this.datasets, (memo, dataset) => {
+      dataset = dataset.data || dataset;
+      const localMin = (_.min(_.pluck(dataset, dependentAxis)));
+      return localMin < 0 ? memo + localMin : memo;
+    })
+  }
+
+  /*const cumulativeMax = _.reduce(formattedData, (memo, dataset) => {
+    const localMax = (_.max(_.pluck(dataset, this.dependentAxis)));
+    return localMax > 0 ? memo + localMax : memo;
+  }, 0);
+  const cumulativeMin = _.reduce(formattedData, (memo, dataset) => {
+    const localMin = (_.min(_.pluck(dataset, this.dependentAxis)));
+    return localMin < 0 ? memo + localMin : memo;
+  }, 0); */
 
   getBarWidth() {
     // todo calculate / enforce max width
@@ -443,6 +463,7 @@ export default class VictoryBar extends React.Component {
   }
 
   _adjustX(x, index, options) {
+    let bandCenter;
     if (this.stringMap.x === null && !this.props.categories) {
       // don't adjust x if the x axis is numeric
       return x;
@@ -454,15 +475,19 @@ export default class VictoryBar extends React.Component {
     const totalWidth = this._pixelsToValue(this.style.data.padding) +
       this._pixelsToValue(this.style.data.width);
     if (this.props.categories && _.isArray(this.props.categories[0])) {
-      // figure out which band this x value belongs to, and shift it to the
-      // center of that band before calculating the usual offset
-      const xBand = _.filter(this.props.categories, (band) => {
-        return (x >= _.min(band) && x <= _.max(band));
-      });
-      const bandCenter = _.isArray(xBand[0]) && (_.max(xBand[0]) + _.min(xBand[0])) / 2;
-      return stacked ? bandCenter : bandCenter + (centerOffset * totalWidth);
+      bandCenter = this.determineCategory(x, this.props);
     }
-    return stacked ? x : x + (centerOffset * totalWidth);
+    bandCenter = bandCenter || x;
+    return stacked ? bandCenter : bandCenter + (centerOffset * totalWidth);
+  }
+
+  determineCategory(x, props) {
+    // figure out which band this x value belongs to, and shift it to the
+    // center of that band before calculating the usual offset
+    const xBand = _.filter(props.categories, (band) => {
+      return (x >= _.min(band) && x <= _.max(band));
+    });
+    return _.isArray(xBand[0]) && (_.max(xBand[0]) + _.min(xBand[0])) / 2;
   }
 
   getYOffset(data, index, barIndex) {


### PR DESCRIPTION
Organize the data into stacked bars/groups and then use the VictoryUtil collections methods to calculate the max and min

note: package.json will need to be changed to point at VictoryUtil master branch once my PR is merged into that repo

cc/ @boygirl 
