### PR TITLE
Move rendering logic out of `docs.jsx`, so third parties can render docs on their own terms

### DIFF
--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import Docs from "./docs";
+
+const content = document.getElementById("content");
+ReactDOM.render(<Docs/>, content);  

--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -28,9 +28,4 @@ class Docs extends React.Component {
   }
 }
 
-if (typeof document !== "undefined") {
-  const content = document.getElementById("content");
-  ReactDOM.render(<Docs/>, content);  
-}
-
 export default Docs;

--- a/docs/static-render-entry.jsx
+++ b/docs/static-render-entry.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactDOM from "react-dom";
 import ReactDOMServer from "react-dom/server";
 
 import Docs from "./docs";
@@ -13,6 +14,12 @@ const _renderIndex = (component) => `<!DOCTYPE html>${ReactDOMServer.renderToSta
  *
  * Output built to `/gh-pages/` 
  */
+
+
+if (typeof document !== "undefined") {
+  const content = document.getElementById("content");
+  ReactDOM.render(<Docs/>, content);
+}
 
 export default (locals, next) => {
   const source = JSON.parse(locals.webpackStats.compilation.assets["stats.json"].source());

--- a/docs/webpack.config.dev.js
+++ b/docs/webpack.config.dev.js
@@ -18,7 +18,7 @@ module.exports = {
   cache: true,
   devtool: "source-map",
   entry: {
-    app: ["./docs/docs.jsx"]
+    app: ["./docs/app.jsx"]
   },
   stats: {
     colors: true,

--- a/docs/webpack.config.dist.js
+++ b/docs/webpack.config.dist.js
@@ -14,7 +14,7 @@ module.exports = {
   cache: true,
   devtool: "source-map",
   entry: {
-    app: ["./docs/docs.jsx"]
+    app: ["./docs/app.jsx"]
   },
   stats: {
     colors: true,

--- a/docs/webpack.config.hot.js
+++ b/docs/webpack.config.hot.js
@@ -10,7 +10,7 @@ mod.loaders[0].loaders = ["react-hot"].concat(mod.loaders[0].loaders);
 
 module.exports = _.merge({}, _.omit(base, "entry", "module"), {
   entry: {
-    app: ["webpack/hot/dev-server", "./docs/docs.jsx"]
+    app: ["webpack/hot/dev-server", "./docs/app.jsx"]
   },
 
   module: mod


### PR DESCRIPTION
This should be a quick one: it moves the

```
if (typeof document !== "undefined") {
  const content = document.getElementById("content");
  ReactDOM.render(<Docs/>, content);  
}
```

stuff out of the `docs.jsx` component and into a new entry point (`app.jsx`, for `npm run dev-docs`) and the static-render entry point. That way, third parties (specifically, the master Victory lander) can require in `docs.jsx` and render it on their own terms.

If this looks legit on your end, I'll repeat the process elsewhere without bugging you with PRs. :)

/cc @boygirl 
