### PR TITLE
Small renderables

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -72,7 +72,7 @@ class App extends React.Component {
             data={this.state.numericBarData}
             labelComponents={[<VictoryLabel>LABELLLL</VictoryLabel>]}
             dataAttributes={[
-              {fill: "cornflowerblue"},
+              {fill: "red"},
               {fill: "orange"},
               {fill: "greenyellow"},
               {fill: "gold"},

--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -29,7 +29,7 @@ class App extends React.Component {
         },
         {
           x: "dogs",
-          y: _.random(-15, 15)
+          y: _.random(0, 15)
         }
       ];
     });
@@ -48,7 +48,7 @@ class App extends React.Component {
         },
         {
           x: _.random(9, 11),
-          y: _.random(-15, 15)
+          y: _.random(0, 15)
         }
       ];
     });
@@ -72,7 +72,7 @@ class App extends React.Component {
             data={this.state.numericBarData}
             labelComponents={[<VictoryLabel>LABELLLL</VictoryLabel>]}
             dataAttributes={[
-              {fill: "red"},
+              {fill: "cornflowerblue"},
               {fill: "orange"},
               {fill: "greenyellow"},
               {fill: "gold"},

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "chai": "^3.2.0",
     "mocha": "^2.2.5",
     "react": "0.14.x",
+    "react-addons-test-utils":  "^0.14.0",
     "react-dom": "0.14.x",
     "react-hot-loader": "^1.2.8",
     "sinon": "^1.15.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "builder": "~2.1.3",
     "builder-victory-component": "~0.0.5",
-    "d3": "^3.5.6",
+    "d3-scale": "^0.2.0",
     "victory-animation": "^0.0.12",
     "victory-util": "^2.0.2",
     "victory-label": "^0.1.6"

--- a/src/components/bar-label.jsx
+++ b/src/components/bar-label.jsx
@@ -1,0 +1,114 @@
+import _ from "lodash";
+import React, { PropTypes } from "react";
+import Radium from "radium";
+import { VictoryLabel } from "victory-label";
+import { VictoryAnimation } from "victory-animation";
+
+@Radium
+export default class BarLabel extends React.Component {
+
+  static propTypes = {
+    animate: PropTypes.object,
+    position: PropTypes.object,
+    horizontal: PropTypes.bool,
+    style: PropTypes.object,
+    data: PropTypes.object,
+    labelText: PropTypes.string,
+    labelComponent: PropTypes.any,
+  };
+
+  getCalculatedValues(props) {
+    this.anchors = this.getLabelAnchors(props);
+    this.position = {
+      x: props.horizontal ? props.position.dependent1 : props.position.independent,
+      y: props.horizontal ? props.position.independent : props.position.dependent1
+    };
+  }
+
+  evaluateStyle(style) {
+    return _.transform(style, (result, value, key) => {
+      result[key] = _.isFunction(value) ? value.call(this, this.props.data) : value;
+    });
+  }
+
+  getLabelAnchors(props) {
+    const sign = props.data.y >= 0 ? 1 : -1;
+    if (!props.horizontal) {
+      return {
+        vertical: sign >= 0 ? "end" : "start",
+        text: "middle"
+      };
+    } else {
+      return {
+        vertical: "middle",
+        text: sign >= 0 ? "start" : "end"
+      };
+    }
+  }
+
+  getlabelPadding(style) {
+    return {
+      x: this.props.horizontal ? style.padding : 0,
+      y: this.props.horizontal ? 0 : style.padding
+    };
+  }
+
+  renderLabelComponent(props) {
+    const component = props.labelComponent;
+    const style = this.evaluateStyle(_.merge({padding: 0}, props.style, component.props.style));
+    const padding = this.getlabelPadding(style);
+    const children = component.props.children || props.labelText;
+    const newProps = {
+      x: component.props.x || this.position.x + padding.x,
+      y: component.props.y || this.position.y - padding.y,
+      data: props.data , // Pass data for custom label component to access
+      textAnchor: component.props.textAnchor || this.anchors.text,
+      verticalAnchor: component.props.verticalAnchor || this.anchors.vertical,
+      style
+    };
+    return React.cloneElement(component, newProps, children)
+  }
+
+  renderVictoryLabel(props) {
+    const style = this.evaluateStyle(_.merge({padding: 0}, props.style));
+    const padding = this.getlabelPadding(style);
+    return (
+      <VictoryLabel
+        x={this.position.x + padding.x}
+        y={this.position.y - padding.y}
+        data={props.data}
+        textAnchor={this.anchors.text}
+        verticalAnchor={this.anchors.vertical}
+        style={style}
+      >
+        {props.labelText}
+      </VictoryLabel>
+    );
+  }
+
+  renderLabel(props) {
+    return props.labelComponent ?
+      this.renderLabelComponent(props) : this.renderVictoryLabel(props);
+  }
+
+  render() {
+    if (this.props.animate) {
+      // Do less work by having `VictoryAnimation` tween only values that
+      // make sense to tween. In the future, allow customization of animated
+      // prop whitelist/blacklist?
+      const animateData = _.pick(this.props, ["position", "style", "data"]);
+      return (
+        <VictoryAnimation {...this.props.animate} data={animateData}>
+          {(props) => <BarLabel {...this.props} {...props} animate={null}/>}
+        </VictoryAnimation>
+      );
+    } else {
+      this.getCalculatedValues(this.props);
+    }
+    return (
+      <g>
+        {this.renderLabel(this.props)}
+      </g>
+    );
+  }
+}

--- a/src/components/bar-label.jsx
+++ b/src/components/bar-label.jsx
@@ -14,7 +14,7 @@ export default class BarLabel extends React.Component {
     style: PropTypes.object,
     data: PropTypes.object,
     labelText: PropTypes.string,
-    labelComponent: PropTypes.any,
+    labelComponent: PropTypes.any
   };
 
   getCalculatedValues(props) {
@@ -61,12 +61,12 @@ export default class BarLabel extends React.Component {
     const newProps = {
       x: component.props.x || this.position.x + padding.x,
       y: component.props.y || this.position.y - padding.y,
-      data: props.data , // Pass data for custom label component to access
+      data: props.data, // Pass data for custom label component to access
       textAnchor: component.props.textAnchor || this.anchors.text,
       verticalAnchor: component.props.verticalAnchor || this.anchors.vertical,
       style
     };
-    return React.cloneElement(component, newProps, children)
+    return React.cloneElement(component, newProps, children);
   }
 
   renderVictoryLabel(props) {

--- a/src/components/bar.jsx
+++ b/src/components/bar.jsx
@@ -75,7 +75,7 @@ export default class Bar extends React.Component {
       // Do less work by having `VictoryAnimation` tween only values that
       // make sense to tween. In the future, allow customization of animated
       // prop whitelist/blacklist?
-      const animateData = _.pick(this.props, ["position", "style"]);
+      const animateData = _.pick(this.props, ["position", "style", "data"]);
       return (
         <VictoryAnimation {...this.props.animate} data={animateData}>
           {(props) => <Bar {...this.props} {...props} animate={null}/>}

--- a/src/components/bar.jsx
+++ b/src/components/bar.jsx
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import React, { PropTypes } from "react";
 import Radium from "radium";
-import { VictoryLabel } from "victory-label";
 import { VictoryAnimation } from "victory-animation";
 
 @Radium
@@ -16,7 +15,7 @@ export default class Bar extends React.Component {
   };
 
   getCalculatedValues(props) {
-    this.style = this.evaluateStyle(props.style)
+    this.style = this.evaluateStyle(props.style);
     this.barWidth = this.style.width;
     this.path = props.position.independent ? this.getBarPath(props.position) : undefined;
   }
@@ -60,7 +59,7 @@ export default class Bar extends React.Component {
     });
   }
 
-  renderBar(props) {
+  renderBar() {
     return (
       <path
         d={this.path}
@@ -86,7 +85,7 @@ export default class Bar extends React.Component {
     }
     return (
       <g>
-        {this.renderBar(this.props)}
+        {this.renderBar()}
       </g>
     );
   }

--- a/src/components/bar.jsx
+++ b/src/components/bar.jsx
@@ -1,0 +1,93 @@
+import _ from "lodash";
+import React, { PropTypes } from "react";
+import Radium from "radium";
+import { VictoryLabel } from "victory-label";
+import { VictoryAnimation } from "victory-animation";
+
+@Radium
+export default class Bar extends React.Component {
+
+  static propTypes = {
+    animate: PropTypes.object,
+    position: PropTypes.object,
+    horizontal: PropTypes.bool,
+    style: PropTypes.object,
+    data: PropTypes.object
+  };
+
+  getCalculatedValues(props) {
+    this.style = this.evaluateStyle(props.style)
+    this.barWidth = this.style.width;
+    this.path = props.position.independent ? this.getBarPath(props.position) : undefined;
+  }
+
+  /*
+   * helper method for getBarPath
+   * called when the bars will be vertical
+   */
+  getVerticalBarPath(position) {
+    const {independent, dependent0, dependent1} = position;
+    const size = this.barWidth / 2;
+    return `M ${independent - size}, ${dependent0}
+      L ${independent - size}, ${dependent1}
+      L ${independent + size}, ${dependent1}
+      L ${independent + size}, ${dependent0}
+      L ${independent - size}, ${dependent0}`;
+  }
+
+  /*
+   * helper method for getBarPath
+   * called when the bars will be horizonal
+   */
+  getHorizontalBarPath(position) {
+    const {independent, dependent0, dependent1} = position;
+    const size = this.barWidth / 2;
+    return `M ${dependent0}, ${independent - size}
+      L ${dependent0}, ${independent + size}
+      L ${dependent1}, ${independent + size}
+      L ${dependent1}, ${independent - size}
+      L ${dependent0}, ${independent - size}`;
+  }
+
+  getBarPath(position) {
+    return this.props.horizontal ?
+      this.getHorizontalBarPath(position) : this.getVerticalBarPath(position);
+  }
+
+  evaluateStyle(style) {
+    return _.transform(style, (result, value, key) => {
+      result[key] = _.isFunction(value) ? value.call(this, this.props.data) : value;
+    });
+  }
+
+  renderBar(props) {
+    return (
+      <path
+        d={this.path}
+        style={this.style}
+        shapeRendering="optimizeSpeed"
+      />
+    );
+  }
+
+  render() {
+    if (this.props.animate) {
+      // Do less work by having `VictoryAnimation` tween only values that
+      // make sense to tween. In the future, allow customization of animated
+      // prop whitelist/blacklist?
+      const animateData = _.pick(this.props, ["position", "style"]);
+      return (
+        <VictoryAnimation {...this.props.animate} data={animateData}>
+          {(props) => <Bar {...this.props} {...props} animate={null}/>}
+        </VictoryAnimation>
+      );
+    } else {
+      this.getCalculatedValues(this.props);
+    }
+    return (
+      <g>
+        {this.renderBar(this.props)}
+      </g>
+    );
+  }
+}

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -2,10 +2,9 @@ import React, { PropTypes } from "react";
 import Radium from "radium";
 import _ from "lodash";
 import d3Scale from "d3-scale";
-import {VictoryAnimation} from "victory-animation";
 import Util from "victory-util";
-import {VictoryLabel} from "victory-label";
 import Bar from "./bar";
+import BarLabel from "./bar-label";
 
 
 const defaultStyles = {
@@ -461,53 +460,6 @@ export default class VictoryBar extends React.Component {
     };
   }
 
-  getLabelAnchors(sign) {
-    if (!this.props.horizontal) {
-      return {
-        vertical: sign >= 0 ? "end" : "start",
-        text: "middle"
-      };
-    } else {
-      return {
-        vertical: "middle",
-        text: sign >= 0 ? "start" : "end"
-      };
-    }
-  }
-
-  getlabelPadding(style) {
-    return {
-      x: this.props.horizontal ? style.padding : 0,
-      y: this.props.horizontal ? 0 : style.padding
-    };
-  }
-
-  renderLabel(labelData, text, data) {
-    const {position, index} = labelData;
-    const labelComponent = this.props.labelComponents ?
-      this.props.labelComponents[index] || this.props.labelComponents[0] : undefined;
-    const sign = data.y >= 0 ? 1 : -1;
-    const anchors = this.getLabelAnchors(sign);
-    const componentStyle = labelComponent && labelComponent.props.style;
-    const style = _.merge({padding: 0}, this.style.labels, componentStyle);
-    const padding = this.getlabelPadding(style);
-    const children = labelComponent ? labelComponent.props.children || text : text;
-
-    const props = {
-      key: `label-${index}`,
-      x: (labelComponent && labelComponent.props.x) || position.x + padding.x,
-      y: (labelComponent && labelComponent.props.y) || position.y - padding.y,
-      data, // Pass data for custom label component to access
-      textAnchor: (labelComponent && labelComponent.props.textAnchor) || anchors.text,
-      verticalAnchor: (labelComponent && labelComponent.props.textAnchor) || anchors.vertical,
-      style
-    };
-
-    return labelComponent ?
-      React.cloneElement(labelComponent, props, children) :
-      React.createElement(VictoryLabel, props, children);
-  }
-
   renderBars(dataset, index) {
     const isCenter = Math.floor(this.datasets.length / 2) === index;
     const isLast = this.datasets.length === index + 1;
@@ -519,39 +471,38 @@ export default class VictoryBar extends React.Component {
         "xName", "yName", "x", "y", "label"
       ]);
       const style = _.merge({}, this.style.data, _.omit(dataset.attrs, "name"), styleData);
-      const plotLabel = (plotGroupLabel && (this.props.labels || this.props.labelComponents));
-
-      if (plotLabel) {
-        const labelPositions = {
-          x: this.props.horizontal ? position.dependent1 : position.independent,
-          y: this.props.horizontal ? position.independent : position.dependent1
-        };
-        const labelIndex = this.getLabelIndex(data.x);
-        const labelData = {position: labelPositions, index: labelIndex};
-        const labelText = this.props.labels ?
-          this.props.labels[labelIndex] || this.props.labels[0] : "";
-        return (
-          <g key={`series-${index}-bar-${barIndex}`}>
-            <Bar
-              animate={this.props.animate}
-              horizontal={this.props.horizontal}
-              style={style}
-              position={position}
-              data={data}
-            />
-            {this.renderLabel(labelData, labelText, data)}
-          </g>
-        );
-      }
-      return (
+      const barComponent = (
         <Bar key={`series-${index}-bar-${barIndex}`}
           animate={this.props.animate}
           horizontal={this.props.horizontal}
-          style={this.style.data}
+          style={style}
           position={position}
           data={data}
         />
       );
+      const plotLabel = (plotGroupLabel && (this.props.labels || this.props.labelComponents));
+      if (plotLabel) {
+        const labelIndex = this.getLabelIndex(data.x);
+        const labelText = this.props.labels ?
+          this.props.labels[labelIndex] || this.props.labels[0] : "";
+        const labelComponent = this.props.labelComponents ?
+          this.props.labelComponents[index] || this.props.labelComponents[0] : undefined;
+        return (
+          <g key={`series-${index}-bar-${barIndex}`}>
+            {barComponent}
+            <BarLabel key={`label-series-${index}-bar-${barIndex}`}
+              animate={this.props.animate}
+              horizontal={this.props.horizontal}
+              style={this.style.labels}
+              position={position}
+              data={data}
+              labelText={labelText}
+              labelComponent={labelComponent}
+            />
+          </g>
+        );
+      }
+      return barComponent;
     });
   }
 
@@ -562,25 +513,7 @@ export default class VictoryBar extends React.Component {
   }
 
   render() {
-    // If animating, return a `VictoryAnimation` element that will create
-    // a new `VictoryBar` with nearly identical props, except (1) tweened
-    // and (2) `animate` set to null so we don't recurse forever.
-    if (this.props.animate) {
-      // Do less work by having `VictoryAnimation` tween only values that
-      // make sense to tween. In the future, allow customization of animated
-      // prop whitelist/blacklist?
-      const animateData = _.pick(this.props, [
-        "data", "dataAttributes", "categories", "colorScale", "domain", "height",
-        "padding", "style", "width"
-      ]);
-      return (
-        <VictoryAnimation {...this.props.animate} data={animateData}>
-          {(props) => <VictoryBar {...this.props} {...props} animate={null}/>}
-        </VictoryAnimation>
-      );
-    } else {
-      this.getCalculatedValues(this.props);
-    }
+    this.getCalculatedValues(this.props);
     const style = this.style.parent;
     const group = <g style={style}>{this.renderData()}</g>;
     return this.props.standalone ? <svg style={style}>{group}</svg> : group;

--- a/test/client/spec/components/victory-bar.spec.jsx
+++ b/test/client/spec/components/victory-bar.spec.jsx
@@ -1,21 +1,33 @@
 /**
  * Client tests
  */
-
+import React from "react";
+import ReactDOM from "react-dom";
+import VictoryBar from "src/components/victory-bar";
 // Use `TestUtils` to inject into DOM, simulate events, etc.
 // See: https://facebook.github.io/react/docs/test-utils.html
+import TestUtils from "react-addons-test-utils";
+
+const getElement = function (output, tagName) {
+  return ReactDOM.findDOMNode(
+    TestUtils.findRenderedDOMComponentWithTag(output, tagName)
+  );
+};
+
+let renderedComponent;
 
 describe("components/victory-bar", () => {
-  it("has expected content with shallow render", () => {
-    // This is a "shallow" render that renders only the current component
-    // without using the actual DOM.
-    //
-    // https://facebook.github.io/react/docs/test-utils.html#shallow-rendering
-    // const renderer = TestUtils.createRenderer();
-    // renderer.render(<Component />);
-    // const output = renderer.getRenderOutput();
+  describe("default component rendering", () => {
+    before(() => {
+      renderedComponent = TestUtils.renderIntoDocument(<VictoryBar/>);
+    });
 
-    // expect(output.type).to.equal("svg");
-    expect(true).to.equal(true);
+    it("renders an svg with the correct width and height", () => {
+
+      const svg = getElement(renderedComponent, "svg");
+      // default width and height
+      expect(svg.style.width).to.equal(`${VictoryBar.defaultProps.width}px`);
+      expect(svg.style.height).to.equal(`${VictoryBar.defaultProps.height}px`);
+    });
   });
 });


### PR DESCRIPTION
this pr
breaks render into smaller components `Bar` and `BarLabels`
supports functional styles
uses `d3-scale` instead of `d3`
adds basic tests

closes #52 
closes #53 
closes #54
