### PR TITLE
PERF: Only transform functional styles

### DIFF
--- a/src/components/bar.jsx
+++ b/src/components/bar.jsx
@@ -52,6 +52,9 @@ export default class Bar extends React.Component {
   }
 
   evaluateStyle(style) {
+    if (!_.some(style, _.isFunction)) {
+      return style;
+    }
     return _.transform(style, (result, value, key) => {
       result[key] = _.isFunction(value) ? value.call(this, this.props.data) : value;
     });


### PR DESCRIPTION
While investigating FormidableLabs/victory#141, I did some profiling and found that `evaluateStyles` was the most time-consuming function in the provided demo. It's currently transforming styles even if it would be a no-op.

This change only transforms style objects that contain functional styles. This increased FPS by ~30% for me. The most time consuming functions are now all in Radium, as I expected from previous tests. We'll need to focus our efforts optimizing Radium (or using it more cautiously) if we'd like to make Victory much faster.

/cc @boygirl @bclinkinbeard
