### PR TITLE
fix (vertical) x-axis ordering for horizontal bar charts

### DIFF
--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -362,9 +362,11 @@ export default class VictoryBar extends React.Component {
     const isVertical = (horizontal && axis === "x") || (!horizontal && axis !== "x");
     const isDependent = (horizontal && !isVertical) || (!horizontal && isVertical);
 
-    return isVertical && isDependent ? [props.height - this.padding.bottom, this.padding.top] :
-      isVertical && !isDependent ? [this.padding.top, props.height - this.padding.bottom] :
-      [this.padding.left, props.width - this.padding.right];
+    if(isVertical) {
+      const bottomToTop = [props.height - this.padding.bottom, this.padding.top];
+      return isDependent ? bottomToTop : bottomToTop.reverse();
+    }
+    return [this.padding.left, props.width - this.padding.right];
   }
 
   getDomain(props, axis) {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -358,11 +358,13 @@ export default class VictoryBar extends React.Component {
 
   getRange(props, axis) {
     // determine how to lay the axis and what direction positive and negative are
-    const isVertical =
-      !this.props.horizontal && axis === "x" || this.props.horizontal && axis !== "x";
+    const {horizontal} = props;
+    const isVertical = (horizontal && axis === "x") || (!horizontal && axis !== "x");
+    const isDependent = (horizontal && !isVertical) || (!horizontal && isVertical);
 
-    return isVertical ? [this.padding.left, props.width - this.padding.right] :
-      [props.height - this.padding.bottom, this.padding.top];
+    return isVertical && isDependent ? [props.height - this.padding.bottom, this.padding.top] :
+      isVertical && !isDependent ? [this.padding.top, props.height - this.padding.bottom] :
+      [this.padding.left, props.width - this.padding.right];
   }
 
   getDomain(props, axis) {

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -362,7 +362,7 @@ export default class VictoryBar extends React.Component {
     const isVertical = (horizontal && axis === "x") || (!horizontal && axis !== "x");
     const isDependent = (horizontal && !isVertical) || (!horizontal && isVertical);
 
-    if(isVertical) {
+    if (isVertical) {
       const bottomToTop = [props.height - this.padding.bottom, this.padding.top];
       return isDependent ? bottomToTop : bottomToTop.reverse();
     }

--- a/test/client/spec/components/victory-bar.spec.jsx
+++ b/test/client/spec/components/victory-bar.spec.jsx
@@ -32,7 +32,7 @@ describe("components/victory-bar", () => {
   });
 
   describe("domain calculation", () => {
-    it("calculates the correct domain", () => {
+    it("calculates the correct domain & range", () => {
       const data = [
         [{x: 1, y: 0}, {x: 2, y: 0}, {x: 3, y: 0}],
         [{x: 1, y: 1}, {x: 2, y: 1}, {x: 3, y: 1}],
@@ -43,9 +43,11 @@ describe("components/victory-bar", () => {
       );
       expect(component.domain.y).to.deep.equal([0, 2]);
       expect(component.domain.x).to.deep.equal([1, 3]);
+      expect(component.range.x[0]).to.be.lessThan(component.range.x[1]);
+      expect(component.range.y[0]).to.be.greaterThan(component.range.y[1]);
     });
 
-    it("calculates the correct domain with negative data", () => {
+    it("calculates the correct domain & range with negative data", () => {
       const data = [
         [{x: 1, y: 0}, {x: 2, y: 0}, {x: 3, y: 0}],
         [{x: 1, y: 1}, {x: 2, y: 1}, {x: 3, y: 1}],
@@ -56,6 +58,23 @@ describe("components/victory-bar", () => {
       );
       expect(component.domain.y).to.deep.equal([-2, 2]);
       expect(component.domain.x).to.deep.equal([1, 3]);
+      expect(component.range.x[0]).to.be.lessThan(component.range.x[1]);
+      expect(component.range.y[0]).to.be.greaterThan(component.range.y[1]);
+    });
+
+    it("calculates the correct domain & range for horizontal bars", () => {
+      const data = [
+        [{x: 1, y: 0}, {x: 2, y: 0}, {x: 3, y: 0}],
+        [{x: 1, y: 1}, {x: 2, y: 1}, {x: 3, y: 1}],
+        [{x: 1, y: 2}, {x: 2, y: 2}, {x: 3, y: -2}]
+      ];
+      const component = TestUtils.renderIntoDocument(
+        <VictoryBar horizontal data={data} domainPadding={0}/>
+      );
+      expect(component.domain.y).to.deep.equal([-2, 2]);
+      expect(component.domain.x).to.deep.equal([1, 3]);
+      expect(component.range.x[0]).to.be.lessThan(component.range.x[1]);
+      expect(component.range.y[0]).to.be.lessThan(component.range.y[1]);
     });
 
     it("calculates a cumulative domain for stacked data", () => {


### PR DESCRIPTION
Addresses issues in #76 - adds a new rule for calculating range for dependent x-axes (ie. the vertical axis in a horizontal bar chart). Added new test to validate.
