### PR TITLE
Injectable bar dependency

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -4,6 +4,22 @@ import React from "react";
 import {VictoryBar} from "../src/index";
 import {VictoryChart} from "victory-chart";
 
+import Bar from "../src/components/bar";
+
+class MyBar extends React.Component {
+
+  handleClick() {
+  }
+
+  render() {
+    return (
+      <g onClick={this.handleClick.bind(this)}>
+        <Bar {...this.props} />
+      </g>
+    );
+  }
+}
+
 export default class App extends React.Component {
   constructor() {
     super();
@@ -154,6 +170,26 @@ export default class App extends React.Component {
               ]
             ]}
             colorScale="warm"
+          />
+        </ChartWrap>
+
+        <ChartWrap>
+          <VictoryBar
+            stacked
+            Bar={MyBar}
+            data={[
+              [
+                {x: "a", y: 2},
+                {x: "b", y: 3},
+                {x: "c", y: 4}
+              ],
+              [
+                {x: "c", y: 2},
+                {x: "d", y: 3},
+                {x: "e", y: 4}
+              ]
+            ]}
+            colorScale="cool"
           />
         </ChartWrap>
       </div>

--- a/src/components/victory-bar.jsx
+++ b/src/components/victory-bar.jsx
@@ -231,7 +231,22 @@ export default class VictoryBar extends React.Component {
       CustomPropTypes.allOfType([CustomPropTypes.integer, CustomPropTypes.nonNegative]),
       PropTypes.string,
       PropTypes.arrayOf(PropTypes.string)
-    ])
+    ]),
+    /**
+     * The BarComponent prop specifies a React component to use in building each bar in your chart.
+     * The value will be used in JSX.
+     * But, by default, Victory's standard Bar component will be used.
+     * @examples 'Bar', 'props => <Bar {...props} />'
+     */
+    BarComponent: PropTypes.func,
+    /**
+     * The BarLabelComponent prop specifies a React component to use in building each label in your
+     * chart.
+     * The value will be used in JSX.
+     * But, by default, Victory's standard BarLabel component will be used.
+     * @examples 'BarLabel', 'props => <BarLabel {...props} />
+     */
+    BarLabelComponent: PropTypes.func
   };
 
   static defaultProps = {
@@ -244,7 +259,9 @@ export default class VictoryBar extends React.Component {
     standalone: true,
     width: 450,
     x: "x",
-    y: "y"
+    y: "y",
+    BarComponent: Bar,
+    BarLabelComponent: BarLabel
   };
 
   static getDomain = DomainHelpers.getDomain.bind(DomainHelpers);
@@ -256,7 +273,7 @@ export default class VictoryBar extends React.Component {
       const baseStyle = calculatedProps.style;
       const style = LayoutHelpers.getBarStyle(datum, dataset, baseStyle);
       const barComponent = (
-        <Bar key={`series-${index}-bar-${barIndex}`}
+        <this.props.BarComponent key={`series-${index}-bar-${barIndex}`}
           horizontal={this.props.horizontal}
           style={style}
           position={position}
@@ -275,7 +292,7 @@ export default class VictoryBar extends React.Component {
         return (
           <g key={`series-${index}-bar-${barIndex}`}>
             {barComponent}
-            <BarLabel key={`label-series-${index}-bar-${barIndex}`}
+            <this.props.BarLabelComponent key={`label-series-${index}-bar-${barIndex}`}
               horizontal={this.props.horizontal}
               style={baseStyle.labels}
               position={position}

--- a/test/client/spec/components/victory-bar.spec.jsx
+++ b/test/client/spec/components/victory-bar.spec.jsx
@@ -8,6 +8,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import _ from "lodash";
 import VictoryBar from "src/components/victory-bar";
+import Bar from "src/components/bar";
 import DomainHelpers from "src/domain-helpers";
 // Use `TestUtils` to inject into DOM, simulate events, etc.
 // See: https://facebook.github.io/react/docs/test-utils.html
@@ -25,6 +26,34 @@ describe("components/victory-bar", () => {
   describe("default component rendering", () => {
     before(() => {
       renderedComponent = TestUtils.renderIntoDocument(<VictoryBar/>);
+    });
+
+    it("renders an svg with the correct width and height", () => {
+      const svg = getElement(renderedComponent, "svg");
+      // default width and height
+      expect(svg.style.width).to.equal(`${VictoryBar.defaultProps.width}px`);
+      expect(svg.style.height).to.equal(`${VictoryBar.defaultProps.height}px`);
+    });
+  });
+
+  describe("rendering with an injected Stateless Function Component", () => {
+    before(() => {
+      const MyBar = (props) => <Bar {...props} />;
+      renderedComponent = TestUtils.renderIntoDocument(<VictoryBar Bar={MyBar} />);
+    });
+
+    it("renders an svg with the correct width and height", () => {
+      const svg = getElement(renderedComponent, "svg");
+      // default width and height
+      expect(svg.style.width).to.equal(`${VictoryBar.defaultProps.width}px`);
+      expect(svg.style.height).to.equal(`${VictoryBar.defaultProps.height}px`);
+    });
+  });
+
+  describe("rendering with a injected factories", () => {
+    before(() => {
+      const myFactory = React.createFactory(Bar);
+      renderedComponent = TestUtils.renderIntoDocument(<VictoryBar Bar={myFactory} />);
     });
 
     it("renders an svg with the correct width and height", () => {


### PR DESCRIPTION
Please consider this humble proposal. I believe it contributes to a simple design to help enable "general interactivity" as in https://github.com/FormidableLabs/victory/issues/111

The goal behind this design change is to enable the use of the dependency injection pattern to enhance the functionality of `Bar` and `BarLabel` when used within a `VictoryBar` component.

A user of victory-bar is able to, for example, replace `VictoryBar`'s implementation of `Bar` with a  decorated version of `Bar` to wire up interactivity. See my trivial addition to demo/demo.jsx for an example of this in use!
